### PR TITLE
Add legacy versions v6 through v8.5

### DIFF
--- a/api/v1/available_versions.json
+++ b/api/v1/available_versions.json
@@ -1,5 +1,14 @@
 {
   "versions": {
+    "6": "versions/v6/v6.0",
+    "7": "versions/v7/v7.0",
+    "7.1": "versions/v7.1/v7.1",
+    "8": "versions/v8/v8.0",
+    "8.1": "versions/v8/v8.1",
+    "8.2": "versions/v8/v8.2",
+    "8.3": "versions/v8/v8.3",
+    "8.4": "versions/v8/v8.4",
+    "8.5": "versions/v8/v8.5",
     "9": "v9",
     "9.1": "v9.1",
     "9.2": "v9.2",

--- a/api/v1/available_versions.json
+++ b/api/v1/available_versions.json
@@ -2,7 +2,7 @@
   "versions": {
     "6": "versions/v6/v6.0",
     "7": "versions/v7/v7.0",
-    "7.1": "versions/v7.1/v7.1",
+    "7.1": "versions/v7/v7.1",
     "8": "versions/v8/v8.0",
     "8.1": "versions/v8/v8.1",
     "8.2": "versions/v8/v8.2",

--- a/versions/v6/v6.0/generator.js
+++ b/versions/v6/v6.0/generator.js
@@ -1,0 +1,243 @@
+//NOTICE: As of version 6, this script will only generate cards correctly for Ocarina of Time bingo
+//and as shuch should be saved alongside the regular bingo script.
+ootBingoGenerator = function (bingoList, opts) {
+	if (!opts) opts = {};
+	var LANG = opts.lang || 'name';
+	var SEED = opts.seed || Math.ceil(999999 * Math.random()).toString();
+	Math.seedrandom(SEED);
+	var MODE = opts.mode || 'normal';
+
+	//giuocob 16-8-12: lineCheckList[] has been replaced to allow for removal of all-child rows
+	//Note: the rowElements relation is simply the inverse of the rowCheckList relation
+	var rowElements = {};
+	rowElements["row1"] = [1, 2, 3, 4, 5];
+	rowElements["row2"] = [6, 7, 8, 9, 10];
+	rowElements["row3"] = [11, 12, 13, 14, 15];
+	rowElements["row4"] = [16, 17, 18, 19, 20];
+	rowElements["row5"] = [21, 22, 23, 24, 25];
+	rowElements["col1"] = [1, 6, 11, 16, 21];
+	rowElements["col2"] = [2, 7, 12, 17, 22];
+	rowElements["col3"] = [3, 8, 13, 18, 23];
+	rowElements["col4"] = [4, 9, 14, 19, 24];
+	rowElements["col5"] = [5, 10, 15, 20, 25];
+	rowElements["tlbr"] = [1, 7, 13, 19, 25];
+	rowElements["bltr"] = [5, 9, 13, 17, 21];
+
+	//Given an object that maps keys to flat arrays, invert said object
+	function invertObject(obj) {
+		var ret = {};
+		Object.keys(obj).forEach(function (key) {
+			obj[key].forEach(function (item) {
+				if (!ret[item]) ret[item] = [];
+				ret[item].push(key);
+			});
+		});
+		return ret;
+	}
+
+	rowCheckList = invertObject(rowElements);
+
+function mirror(i) {
+	if      (i == 0) { i = 4; }
+	else if (i == 1) { i = 3; }
+	else if (i == 3) { i = 1; }
+	else if (i == 4) { i = 0; }
+	return i;
+}
+
+function difficulty(i) {
+	// To create the magic square we need 2 random orderings of the numbers 0, 1, 2, 3, 4.
+	// The following creates those orderings and calls them Table5 and Table1
+	
+	var Num3 = SEED%1000;	// Table5 will use the ones, tens, and hundreds digits.
+
+	var Rem8 = Num3%8;
+	var Rem4 = Math.floor(Rem8/2);
+	var Rem2 = Rem8%2;
+	var Rem5 = Num3%5;
+	var Rem3 = Num3%3;	// Note that Rem2, Rem3, Rem4, and Rem5 are mathematically independent.
+	var RemT = Math.floor(Num3/120);	// This is between 0 and 8		
+
+	// The idea is to begin with an array containing a single number, 0.
+	// Each number 1 through 4 is added in a random spot in the array's current size.
+	// The result - the numbers 0 to 4 are in the array in a random (and uniform) order.
+	var Table5 = [0];
+	Table5.splice(Rem2, 0, 1);
+	Table5.splice(Rem3, 0, 2);
+	Table5.splice(Rem4, 0, 3);
+	Table5.splice(Rem5, 0, 4);
+
+	Num3 = Math.floor(SEED/1000);	// Table1 will use the next 3 digits.
+	Num3 = Num3%1000;
+
+	Rem8 = Num3%8;
+	Rem4 = Math.floor(Rem8/2);
+	Rem2 = Rem8%2;
+	Rem5 = Num3%5;
+	Rem3 = Num3%3;
+	RemT = RemT * 8 + Math.floor(Num3/120);	 // This is between 0 and 64.
+
+	var Table1 = [0];
+	Table1.splice(Rem2, 0, 1);
+	Table1.splice(Rem3, 0, 2);
+	Table1.splice(Rem4, 0, 3);
+	Table1.splice(Rem5, 0, 4);
+
+	i--;
+	RemT = RemT%5;		//  Between 0 and 4, fairly uniformly.
+	x = (i+RemT)%5;		//  RemT is horizontal shift to put any diagonal on the main diagonal.
+	y = Math.floor(i/5);
+
+	// The Tables are set into a single magic square template
+	// Some are the same up to some rotation, reflection, or row permutation.
+	// However, all genuinely different magic squares can arise in this fashion.
+	var e5 = Table5[(x + 3*y)%5];
+	var e1 = Table1[(3*x + y)%5];
+
+	// Table5 controls the 5* part and Table1 controls the 1* part.
+	value = 5*e5 + e1;
+
+	if (MODE == "short") { value = Math.floor(value/2); } // if short mode, limit difficulty
+    	else if (MODE == "long") { value = Math.floor((value + 25) / 2); }
+    	value++;
+console.debug(value);
+	return value;
+}
+
+function getShuffledGoals(difficulty)
+{
+	var newArray = bingoList[difficulty].slice();
+	for(var i=0;i<newArray.length;i++)
+	{
+		var randElement = Math.floor(Math.random()*(i+1));
+		var temp = newArray[i];
+		newArray[i] = newArray[randElement];
+		newArray[randElement] = temp;
+	}
+	return newArray;
+}
+  
+
+
+function checkLine(i, testsquare)
+{
+	var typesA = testsquare.types;
+	var synergy = 0;
+	var rows = rowCheckList[i], elements = [];
+	var childCount = 0;
+	for(var k=0;k<rows.length;k++)
+	{
+		elements = rowElements[rows[k]];
+		childCount = 0;
+		for(var m=0;m<elements.length;m++)
+		{
+			var typesB = bingoBoard[elements[m]].types;
+			if(typeof typesB != 'undefined')
+			{
+				for(var n=0;n<typesA.length;n++)
+				{
+					for(var p=0;p<typesB.length;p++)
+					{
+						if(typesA[n] == typesB[p])
+						{
+							synergy++; //if match increase
+							if(n==0) { synergy++ }; //if main type increase
+							if(p==0) { synergy++ }; //if main type increase
+						}
+					}
+				}
+			}
+			if(bingoBoard[elements[m]].child == "yes")
+			{
+				childCount++;
+			}
+		}
+		//Remove child-only rows, remove adult goals from short
+		if(MODE == "short")
+		{
+			if(testsquare.child == "no")
+			{
+				childCount--;
+			}
+			console.debug(rows[k]);
+			console.debug(childCount);
+			if(childCount < 5)
+			{
+				synergy += 3;
+			}
+		}
+		else
+		{
+			if(testsquare.child == "yes")
+			{
+				childCount++;
+			}
+			if(childCount > 4)
+			{
+				synergy += 3;
+			}
+		}
+	}
+	return synergy;
+}
+
+
+
+  var bingoBoard = []; //the board itself stored as an array first
+  for (var i=1;i<=25;i++) {
+	if(MODE == "short")
+	{
+        bingoBoard[i] = {difficulty: difficulty(i), child: "yes"};
+    }
+    else
+    {
+		bingoBoard[i] = {difficulty: difficulty(i), child: "no"};
+	}
+  }                                          // in order 1-25
+  
+    //Populate the bingo board in the array
+    //giuocob 16-8-12: changed this section to:
+    //1. Support uniform goal selection by shuffling arrays before checking goals
+    //2. Remove all child rows by checking child tag
+    //3. If no goal is suitable, instead of choosing goal with lowest synergy, now next difficulty up is checked
+    //   Silly 26-difficulty goals have been added that appear only if the generator runs out of viable goals
+    //   (aka a defect in the goal list)
+    for(var i=1;i<=25;i++)
+    {
+		var getDifficulty = bingoBoard[i].difficulty;
+		var goalArray = getShuffledGoals(getDifficulty);
+		var j=0, synergy=0, currentObj=null, minSynObj=null;
+		do
+		{
+			currentObj = goalArray[j];
+			synergy = checkLine(i,currentObj);
+			if(minSynObj == null || synergy < minSynObj.synergy)
+			{
+				minSynObj = {synergy: synergy, value: currentObj};
+			}
+			j++;
+			if(j >= goalArray.length)
+			{
+				getDifficulty++;
+				if(getDifficulty > 25)
+				{
+					break;
+				}
+				else
+				{
+				    goalArray = getShuffledGoals(getDifficulty);
+				    j = 0;
+				}
+			}
+		} while(synergy != 0);   //Perhaps increase to 1 if difficulty increases happen too often
+		
+    
+    bingoBoard[i].types = minSynObj.value.types;
+    bingoBoard[i].name = minSynObj.value[LANG] || minSynObj.value.name;
+    bingoBoard[i].child = minSynObj.value.child;
+    bingoBoard[i].synergy = minSynObj.synergy;
+  }
+
+  return bingoBoard;
+  
+}

--- a/versions/v6/v6.0/goal-list.js
+++ b/versions/v6/v6.0/goal-list.js
@@ -1,0 +1,256 @@
+var bingoList = [];
+bingoList["info"] = {
+  version: "v6.0"
+};
+bingoList[1] = [
+  { name: "Bullet Bag (50)", jp: 'デクのタネ袋(50)', types: ["bulletbag"], child: "yes" },
+  { name: "Defeat a Skull Kid", jp: 'スタルキッド撃破', types: ["skullkid"], child: "no" },
+  { name: "Bottled Fish", jp: 'ビン(魚)', types: ["bottle"], child: "yes" },
+  { name: "Bottled Fairy", jp: 'ビン(妖精)', types: ["bottle"], child: "yes" },
+  { name: "Red Potion", jp: '赤いクスリ', types: ["bottle"], child: "yes" },
+  { name: "Green Potion", jp: '緑のクスリ', types: ["bottle"], child: "yes" },
+  { name: "Bottled Poe", jp: 'ビン(ポウ)', types: ["bottle"], child: "yes" },
+  { name: "Lens of Truth", jp: 'まことのメガネ', types: ["botw"], child: "yes" }
+];
+bingoList[2] = [
+  { name: "Fairy Slingshot", jp: '妖精のパチンコ', types: ["bulletbag", "deku"], child: "yes" },
+  { name: "Bullet Bag (40)", jp: 'デクのタネ袋(40)', types: ["bulletbag", "deku"], child: "yes" },
+  { name: "Pocket Cucco", jp: 'てのりコッコ', types: ["atrade", "strength"], child: "no" },
+  { name: "Map & Compass in Deku Tree", jp: 'デクの樹様の中のマップとコンパス', types: ["deku", "dungeon_item"], child: "yes" },
+  { name: "At least 30 Deku Nuts", jp: 'デクの実30個以上', types: ["nuts", "forest"], child: "yes" }
+];
+bingoList[3] = [
+  { name: "Map & Compass in Dodongo's Cavern", jp: 'ドドンゴの洞窟のマップとコンパス', types: ["dc", "dungeon_item"], child: "yes" },
+  { name: "Cojiro", jp: 'コジロー', types: ["atrade", "fortress"], child: "yes" },
+  { name: "Ruto's Letter", jp: 'ルトの手紙', types: ["ruto"], child: "yes" },
+  { name: "Map & Compass in Bottom of the Well", jp: '井戸の底のマップとコンパス', types: ["botw", "dungeon_item"], child: "yes" },
+  { name: "Black Gauntlets", jp: '黒のグローブ', types: ["strength", "bulletbag", "atrade"], child: "no" },
+  { name: "Goron Tunic", jp: 'ゴロンの服', types: ["sets", "dmc", "fire"], child: "no" }
+];
+bingoList[4] = [
+  { name: "Adult's Wallet", jp: '大人のサイフ', types: ["wallet", "skulltula", "atrade"], child: "yes" },
+  { name: "Bomb Bag (30)", jp: 'ボム袋(30)', types: ["bombbag", "dc", "atrade"], child: "yes" },
+  { name: "Odd Potion", jp: 'あやしいクスリ', types: ["atrade"], child: "no" },
+  { name: "Minuet of Forest", jp: '森のメヌエット', types: ["forest", "songs"], child: "no" },
+  { name: "Bomb Bag (40)", jp: 'ボム袋(40)', types: ["bombbag", "atrade"], child: "yes" },
+  { name: "Quiver (40)", jp: '矢立て(40)', types: ["atrade", "forest", "quiver"], child: "no" },
+  { name: "Zora Tunic", jp: 'ゾーラの服', types: ["sets", "ice"], child: "no" },
+  { name: "Bolero of Fire", jp: '炎のボレロ', types: ["dmc", "fire", "songs"], child: "no" }
+];
+bingoList[5] = [
+  { name: "Goron's Ruby", jp: 'ゴロンのルビー', types: ["dc", "atrade"], child: "yes" },
+  { name: "Kokiri's Emerald", jp: 'コキリのヒスイ', types: ["deku", "atrade"], child: "yes" },
+  { name: "Defeat Queen Gohma", jp: 'ゴーマ撃破', types: ["deku", "ganon"], child: "yes" },
+  { name: "Map & Compass in Shadow Temple", jp: '闇の神殿のマップとコンパス', types: ["shadow", "dungeon_item"], child: "yes" },
+  { name: "Both heart pieces in Death Mountain Crater", jp: 'デスマウンテン火口のハートのかけら２つ', types: ["dmc", "fire", "hearts"], child: "yes" },
+  { name: "At least 3 songs", jp: '歌3つ以上', types: ["songs"], child: "yes" },
+  { name: "30 Deku Sticks", jp: 'デクの棒30本', types: ["atrade", "masks"], child: "yes" },
+  { name: "Fill all 4 Bottle Slots", jp: '4つの空きビンスロットを全て埋める', types: ["bottle"], child: "yes" },
+  { name: "Cow in House", jp: '牛(リンクの家)', types: ["cow"], child: "no" }
+];
+bingoList[6] = [
+  { name: "Beat Dodongo's Cavern", jp: 'ドドンゴの洞窟クリア', types: ["dc", "fortress"], child: "yes" },
+  { name: "Defeat all Lizalfos in Dodongo's Cavern", jp: 'ドドンゴの洞窟のリザルフォス全て撃破', types: ["dc"], child: "yes" },
+  { name: "Milk", jp: 'ロンロン牛乳', types: ["lonlon", "zl"], child: "yes" },
+  { name: "Beat the Deku Tree", jp: 'デクの樹様の中クリア', types: ["deku", "ganon"], child: "yes" },
+  { name: "Epona's Song", jp: 'エポナの歌', types: ["lonlon", "songs"], child: "yes" },
+  { name: "3 Maps", jp: 'マップ3つ', types: ["dungeon_item"], child: "yes" },
+  { name: "3 Compasses", jp: 'コンパス3つ', types: ["dungeon_item"], child: "yes" },
+  { name: "All 3 Kokiri Forest area Skulltulas", jp: 'コキリの森エリアの黄金のスタルチュラ３匹', types: ["skulltula"], child: "no" },
+  { name: "Defeat King Dodongo", jp: 'キングドドンゴ撃破', types: ["dc"], child: "yes" }
+];
+bingoList[7] = [
+  { name: "Fire Temple Boss Key", jp: '炎の神殿のボス部屋のカギ', types: ["fire", "dungeon_item"], child: "no" },
+  { name: "2 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ2つ', types: ["fortress"], child: "yes" },
+  { name: "Ice Arrows", jp: '氷の矢', types: ["fortress", "water"], child: "yes" },
+  { name: "Defeat Big Octo", jp: '大オクタ撃破', types: ["jabu"], child: "yes" },
+  { name: "3 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ3つ', types: ["fortress"], child: "yes" },
+  { name: "Defeat a White Wolfos", jp: 'ホワイトウルフォス撃破', types: ["ice", "fortress"], child: "yes" },
+  { name: "Defeat Phantom Ganon", jp: 'ファントムガノン撃破', types: ["forest"], child: "no" },
+  { name: "Requiem of Spirit", jp: '魂のレクイエム', types: ["spirit", "songs"], child: "yes" },
+  { name: "3 Tunics", jp: '服3種類', types: ["sets", "ice"], child: "no" }
+];
+bingoList[8] = [
+  { name: "Forest Medallion", jp: '森のメダル', types: ["forest", "lightarrow", "atrade"], child: "no" },
+  { name: "Map & Compass in Jabu-Jabu", jp: 'ジャブジャブ様のお腹のマップとコンパス', types: ["jabu", "dungeon_item"], child: "yes" },
+  { name: "Blue Fire", jp: '青い炎', types: ["ice", "bottle", "deku", "ganon"], child: "yes" },
+  { name: "5 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ5つ', types: ["fortress"], child: "yes" },
+  { name: "Poacher's Saw", jp: '密猟者のノコギリ', types: ["atrade", "zl"], child: "no" },
+  { name: "4 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ4つ', types: ["fortress"], child: "yes" },
+  { name: "37th heart piece (Child Fortress)", jp: '37番目のハートのかけら(子供のゲルドの砦)', types: ["fortress"], child: "yes" },
+  { name: "Beat the Forest Temple", jp: '森の神殿クリア', types: ["forest"], child: "no" },
+  { name: "6 Hearts", jp: 'ハート6つ', types: ["hearts"], child: "yes" },
+  { name: "Giant's Knife", jp: '巨人のナイフ', types: ["sets"], child: "no" }
+];
+bingoList[9] = [
+  { name: "At least 7 Magic Beans", jp: '魔法のマメ7つ以上', types: ["beans", "skulltula"], child: "yes" },
+  { name: "All 4 Lost Woods area Skulltulas", jp: '迷いの森エリアの黄金のスタルチュラ4匹', types: ["skulltula", "forest"], child: "no" },
+  { name: "Ice Cavern Heart Piece", jp: '氷の洞窟のハートのかけら', types: ["ice"], child: "yes" },
+  { name: "Map & Compass in Ice Cavern", jp: '氷の洞窟のマップとコンパス', types: ["ice", "dungeon_item"], child: "no" },
+  { name: "All 3 Skulltulas in Ice Cavern", jp: '氷の洞窟の黄金のスタルチュラ3匹', types: ["ice", "skulltula"], child: "yes" },
+  { name: "Ganon's Castle Boss Key", jp: 'ガノン城のボス部屋のカギ', types: ["ganon", "deku", "dungeon_item"], child: "yes" },
+  { name: "6 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ6つ', types: ["fortress"], child: "yes" }
+];
+
+bingoList[10] = [
+  { name: "All 4 Skulltulas in Jabu-Jabu", jp: 'ジャブジャブ様のお腹の黄金のスタルチュラ4匹', types: ["jabu", "skulltula"], child: "yes" },
+  { name: "Both Gerudo's Fortress area Skulltulas", jp: 'ゲルドの砦の黄金のスタルチュラ2匹', types: ["skulltula", "fortress"], child: "no" },
+  { name: "All 4 Skulltulas in Deku Tree", jp: 'デクの樹様の中の黄金のスタルチュラ4匹', types: ["deku", "skulltula"], child: "yes" },
+  { name: "4 Maps", jp: 'マップ4つ', types: ["dungeon_item", "claimcheck"], child: "yes" },
+  { name: "4 Compasses", jp: 'コンパス4つ', types: ["dungeon_item"], child: "yes" },
+  { name: "Iron Boots", jp: 'ヘビーブーツ', types: ["ice", "sets"], child: "yes" },
+  { name: "Serenade of Water", jp: '水のセレナーデ', types: ["atrade", "ice", "songs"], child: "no" },
+  { name: "Prelude of Light", jp: '光のプレリュード', types: ["songs", "atrade", "forest"], child: "no" }
+];
+bingoList[11] = [
+  { name: "3 Boots", jp: '靴3種類', types: ["sets", "ice"], child: "yes" },
+  { name: "At least 4 songs", jp: '歌4つ以上', types: ["songs", "atrade"], child: "yes" },
+  { name: "Blue Potion", jp: '青いクスリ', types: ["atrade"], child: "no" },
+  { name: "Plant bean in Death Mountain Crater", jp: 'デスマウンテン火口の土にマメを植える', types: ["dmc", "beans"], child: "yes" },
+  { name: "Water Temple Boss Key", jp: '水の神殿のボス部屋のカギ', types: ["water", "fortress", "dungeon_item"], child: "no" },
+  { name: "Water Medallion", jp: '水のメダル', types: ["water", "lightarrow", "atrade"], child: "no" }
+];
+bingoList[12] = [
+  { name: "All 5 Skulltulas in Dodongo's Cavern", jp: 'ドドンゴの洞窟の黄金のスタルチュラ5匹', types: ["dc", "skulltula"], child: "yes" },
+  { name: "At least 5 songs", jp: '歌5つ以上', types: ["songs", "atrade"], child: "no" },
+  { name: "Defeat Barinade", jp: 'バリネード撃破', types: ["jabu"], child: "yes" },
+  { name: "Broken Goron's Sword", jp: '折れたゴロン刀(トレードアイテム)', types: ["atrade", "zl"], child: "no" },
+  { name: "Get Bombchu chest in Spirit Temple", jp: '魂の神殿のボムチュウ取得', types: ["spirit", "strength"], child: "yes" }
+];
+bingoList[13] = [
+  { name: "Defeat Morpha", jp: 'モーファ撃破', types: ["water"], child: "no" },
+  { name: "Beat Jabu-Jabu's Belly", jp: 'ジャブジャブ様のお腹クリア', types: ["jabu"], child: "yes" },
+  { name: "Keaton Mask", jp: 'キータンのお面', types: ["masks", "zl"], child: "yes" },
+  { name: "Double Magic", jp: '魔力2倍', types: ["dmc", "zl"], child: "yes" },
+  { name: "Giant's Wallet", jp: '巨人のサイフ', types: ["wallet", "atrade", "skulltula"], child: "yes" },
+  { name: "3 Swords & 3 Tunics", jp: '剣3種類と服3種類', types: ["sets", "ice"], child: "no" },
+  { name: "Beat the Water Temple", jp: '水の神殿クリア', types: ["water"], child: "no" }
+];
+bingoList[14] = [
+  { name: "At least 9 Magic Beans", jp: '魔法のマメ9つ以上', types: ["beans", "skulltula"], child: "yes" },
+  { name: "Map & Compass in Water Temple", jp: '水の神殿のマップとコンパス', types: ["water", "zl", "ice", "dungeon_item"], child: "no" },
+  { name: "Silver Gauntlets", jp: '銀のグローブ', types: ["strength", "spirit"], child: "yes" },
+  { name: "500 Rupees", jp: '500ルピー', types: ["wallet", "atrade", "skulltula"], child: "no" },
+  { name: "Double Defense", jp: '防御力2倍', types: ["zl", "ganon"], child: "no" },
+  { name: "At least 6 songs", jp: '歌6つ以上', types: ["songs", "atrade"], child: "no" },
+  { name: "Farore's Wind", jp: 'フロルの風', types: ["zl", "ice"], child: "yes" },
+  { name: "All 4 Wasteland/ Colossus area Skulltulas", jp: '幻影の砂漠・巨大邪神像エリアの黄金のスタルチュラ4匹', types: ["skulltula", "spirit"], child: "no" }
+];
+bingoList[15] = [
+  { name: "Megaton Hammer", jp: 'メガトンハンマー', types: ["fire"], child: "no" },
+  { name: "7 Hearts", jp: 'ハート7つ', types: ["hearts"], child: "yes" },
+  { name: "3 Tunics & 3 Boots", jp: '服3種類と靴3種類', types: ["sets", "ice"], child: "no" },
+  { name: "Defeat both Flare Dancers", jp: 'フレアダンサー2体撃破', types: ["fire"], child: "no" },
+  { name: "Saria's Song", jp: 'サリアの歌', types: ["strength", "masks", "songs", "zl"], child: "yes" },
+  { name: "Gerudo's Card", jp: 'ゲルドの会員証', types: ["fortress"], child: "yes" },
+  { name: "Map & Compass in Fire Temple", jp: '炎の神殿のマップとコンパス', types: ["fire", "dungeon_item"], child: "no" },
+  { name: "Fairy Bow", jp: '妖精の弓', types: ["forest", "quiver"], child: "no" },
+  { name: "Forest Temple Boss Key", jp: '森の神殿のボス部屋のカギ', types: ["forest", "dungeon_item", "claimcheck"], child: "no" }
+];
+bingoList[16] = [
+  { name: "Defeat Volvagia", jp: 'ヴァルバジア撃破', types: ["fire", "sets"], child: "no" },
+  { name: "Mirror Shield", jp: 'ミラーシールド', types: ["sets", "spirit", "mirror"], child: "yes" },
+  { name: "Defeat Amy (Green Poe)", jp: 'エイミー撃破(緑のポウ)ｴ', types: ["forest", "quiver"], child: "no" },
+  { name: "All 5 Skulltulas in Forest Temple", jp: '森の神殿の黄金のスタルチュラ5匹', types: ["forest", "skulltula"], child: "no" },
+  { name: "Map & Compass in Forest Temple", jp: '森の神殿のマップとコンパス', types: ["forest", "quiver", "dungeon_item"], child: "no" },
+  { name: "Bottled Big Poe", jp: 'ビン(ビッグポウ)', types: ["bigpoe", "quiver"], child: "no" },
+  { name: "Skull Mask", jp: 'ドクロのお面', types: ["masks", "zl"], child: "yes" },
+  { name: "Treasure Chest Game Heart Piece", jp: '宝箱ゲームのハートのかけら', types: ["zl", "luck"], child: "yes" },
+  { name: "All 8 Kakariko area Skulltulas", jp: 'カカリコ村エリアの黄金のスタルチュラ8匹', types: ["skulltula", "botw"], child: "no" }
+];
+bingoList[17] = [
+
+  { name: "Both heart pieces in Lost Woods", jp: '迷いの森のハートのかけら２つ', types: ["strength", "masks", "songs", "zl"], child: "yes" },
+  { name: "Beat the Fire Temple", jp: '炎の神殿クリア', types: ["fire", "sets", "forest"], child: "no" },
+  { name: "All 4 Lon-Lon Ranch area Skulltulas", jp: 'ロンロン牧場エリアの黄金のスタルチュラ4匹', types: ["jabu", "lonlon", "skulltula"], child: "yes" },
+  { name: "5 Compasses", jp: 'コンパス5つ', types: ["dungeon_item", "compass"], child: "yes" },
+  { name: "Shadow Temple Boss Key", jp: '闇の神殿のボス部屋のカギ', types: ["shadow", "zl", "dungeon_item"], child: "no" },
+  { name: "5 Maps", jp: 'マップ5つ', types: ["dungeon_item", "claimcheck"], child: "yes" },
+  { name: "Prescription", jp: '処方箋', types: ["atrade"], child: "no" },
+  { name: "All 4 Gerudo Valley area Skulltulas", jp: 'ゲルドの谷エリアの黄金のスタルチュラ4匹', types: ["skulltula", "jabu"], child: "no" }
+
+];
+bingoList[18] = [
+  { name: "7 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ7つ', types: ["fortress"], child: "no" },
+  { name: "Defeat Dark Link", jp: 'ダークリンク撃破', types: ["water"], child: "no" },
+  { name: "Longshot", jp: 'ロングフック', types: ["water"], child: "no" },
+  { name: "Din's Fire", jp: 'ディンの炎', types: ["zl"], child: "yes" },
+  { name: "Defeat Bongo-Bongo", jp: 'ボンゴボンゴ撃破', types: ["shadow", "zl"], child: "no" },
+  { name: "Get to the end of Light Trial", jp: '光の結界の最後の部屋に到達', types: ["ganon", "zl", "strength"], child: "no" },
+  { name: "3 Swords & 3 Boots", jp: '剣3種類と靴3種類', types: ["sets", "ice"], child: "no" },
+  { name: "Get to the end of Fire Trial", jp: '炎の結界の最後の部屋に到達', types: ["ganon", "strength",], child: "no" },
+  { name: "Goron Bracelet", jp: 'ゴロンの腕輪', types: ["strength", "zl"], child: "yes" },
+  { name: "Golden Gauntlets", jp: '金のグローブ', types: ["strength", "ganon", "deku"], child: "yes" },
+  { name: "At least 7 songs", jp: '歌7つ以上', types: ["songs", "atrade"] }
+
+];
+bingoList[19] = [
+
+  { name: "All 5 Skulltulas in Fire Temple", jp: '炎の神殿の黄金のスタルチュラ5匹', types: ["fire", "skulltula"], child: "no" },
+  { name: "Stone of Agony", jp: 'もだえ石', types: ["agony", "skulltula"], child: "yes" },
+  { name: "Bombchu Bowling Heart Piece", jp: 'ボムチュウボウリングのハートのかけら', types: ["dc"], child: "yes" },
+  { name: "Nayru's Love", jp: 'ネールの愛', types: ["spirit", "zl"], child: "yes" },
+  { name: "All 3 Skulltulas in Bottom of the Well", jp: '井戸の底の黄金のスタルチュラ3匹', types: ["botw", "skulltula"], child: "yes" },
+  { name: "3 Boss Keys", jp: 'ボス部屋のカギ3つ', types: ["dungeon_item", "claimcheck"], child: "no" },
+  { name: "Beat the Shadow Temple", jp: '闇の神殿クリア', types: ["shadow", "zl"], child: "no" }
+];
+bingoList[20] = [
+  { name: "Defeat Meg (purple Poe)", jp: 'メグ撃破(紫のポウ)', types: ["forest", "quiver"], child: "no" },
+  { name: "Spirit Temple Boss Key", jp: '魂の神殿のボス部屋のカギ', types: ["spirit", "lightarrow", "zl", "dungeon_item"], child: "no" },
+  { name: "Fire Arrow", jp: '炎の矢', types: ["water", "fire", "quiver"] },
+  { name: "All 8 Death Mountain area Skulltulas", jp: 'デスマウンテンエリアの黄金のスタルチュラ8匹', types: ["skulltula", "dmc"], child: "no" },
+  { name: "8 Hearts", jp: 'ハート8つ', types: ["hearts"], child: "yes" },
+  { name: "Spooky Mask", jp: 'こわそなお面', types: ["masks", "strength", "zl"], child: "yes" }
+];
+bingoList[21] = [
+  { name: "8 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ8つ', types: ["fortress"], child: "no" },
+  { name: "Defeat Nabooru-Knuckle", jp: 'アイアンナック(ナボール)撃破', types: ["spirit"], child: "no" },
+  { name: "Get to the end of Water Trial", jp: '水の結界の最後の部屋に到達', types: ["ganon", "fire", "lightarrow"] },
+  { name: "Quiver (50)", jp: '矢立て(50)', types: ["quiver", "fortress"], child: "no" },
+  { name: "Both Hyrule Field area Skulltulas", jp: 'ハイラル平原エリアの黄金のスタルチュラ2匹', types: ["skulltula", "zl"], child: "yes" },
+  { name: "At least 8 songs", jp: '歌8つ以上', types: ["songs", "atrade"], child: "no" },
+  { name: "3 Shields & 3 Tunics", jp: '盾3種類と服3種類', types: ["sets", "spirit"], child: "no" },
+  { name: "3 Swords & 3 Shields", jp: '剣3種類と盾3種類', types: ["sets", "spirit"], child: "no" }
+];
+bingoList[22] = [
+  { name: "All 5 Skulltulas in Shadow Temple", jp: '闇の神殿の黄金のスタルチュラ5匹', types: ["shadow", "skulltula", "zl"], child: "no" },
+  { name: "Blue Gauntlets", jp: '青のグローブ', types: ["spirit", "strength", "bulletbag", "atrade"], child: "no" },
+  { name: "Light Arrows", jp: '光の矢', types: ["lightarrow", "atrade"], child: "no" },
+  { name: "Claim Check", jp: 'ひきかえ券', types: ["atrade", "claimcheck"], child: "no" },
+  { name: "Get to the end of Shadow Trial", jp: '闇の結界の最後の部屋に到達', types: ["ganon", "fire"], child: "no" },
+  { name: "9 Hearts", jp: 'ハート9つ', types: ["hearts"], child: "yes" },
+  { name: "6 Maps", jp: 'マップ6つ', types: ["dungeon_item", "claimcheck"], child: "yes" }
+];
+bingoList[23] = [
+  { name: "Map & Compass in Spirit Temple", jp: '魂の神殿のマップとコンパス', types: ["spirit", "zl", "dungeon_item"], child: "yes" },
+  { name: "3 Shields & 3 Boots", jp: '盾3種類と靴3種類', types: ["sets", "spirit", "ice"], child: "yes" },
+  { name: "Beat the Spirit Temple", jp: '魂の神殿クリア', types: ["spirit"], child: "no" },
+  { name: "All 8 Zora's Domain area Skulltulas", jp: 'ゾーラの里エリアの黄金のスタルチュラ8匹', types: ["jabu", "strength", "ice"], child: "no" },
+  { name: "Defeat Twinrova", jp: 'ツインローバ撃破', types: ["spirit"], child: "no" },
+  { name: "Bunny Hood", jp: 'ウサギずきん', types: ["masks", "strength", "zl", "beans"], child: "yes" },
+  { name: "Get to the end of the Forest Trial", jp: '森の結界の最後の部屋に到達', types: ["ganon", "zl"], child: "no" },
+  { name: "6 Compasses", jp: 'コンパス6つ', types: ["dungeon_item"], child: "yes" }
+];
+bingoList[24] = [
+  { name: "Green Gauntlets", jp: '緑のグローブ', types: ["strength", "bulletbag", "zl", "atrade"], child: "no" },
+  { name: "Bronze Gauntlets", jp: '銅のグローブ', types: ["strength", "bulletbag", "ganon", "atrade"], child: "no" },
+  { name: "Frog's Heart Piece", jp: 'カエルのハートのかけら(嵐の歌)', types: ["songs", "forest"], child: "no" },
+  { name: "All 5 Skulltulas in Spirit Temple", jp: '魂の神殿の黄金のスタルチュラ5匹', types: ["spirit", "jabu", "skulltula"], child: "yes" },
+  { name: "At least 9 songs", jp: '歌9つ以上', types: ["songs", "atrade", "zl"], child: "no" },
+  { name: "All 5 Lake Hylia Skulltulas", jp: 'ハイリア湖畔エリアの黄金のスタルチュラ5匹', types: ["ice", "skulltula", "water"], child: "no" }
+];
+bingoList[25] = [
+  { name: "9 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ9つ', types: ["fortress", "ice"], child: "no" },
+  { name: "All 4 Market area Skulltulas", jp: '城下町エリアの黄金のスタルチュラ4匹', types: ["skulltula", "forest"], child: "no" },
+  { name: "All 5 Skulltulas in Water Temple", jp: '水の神殿の黄金のスタルチュラ5匹', types: ["water"], child: "no" },
+  { name: "Defeat Ganon", jp: 'ガノン撃破', types: ["ganon", "deku", "lightarrow", "atrade"], child: "yes" },
+  { name: "Biggoron窶冱 Sword", jp: "ダイゴロン刀", types: ["atrade", "sets", "claimcheck"], child: "no" },
+  { name: "At least 10 songs", jp: '歌10個以上', types: ["songs", "atrade", "zl"], child: "no" },
+  { name: "Get to the end of Spirit Trial", jp: '魂の結界の最後の部屋に到達', types: ["ganon", "spirit", "quiver"], child: "no" },
+  { name: "7 Maps", jp: 'マップ7つ', types: ["dungeon_item", "claimcheck"], child: "no" },
+  { name: "7 Compasses", jp: 'コンパス7つ', types: ["dungeon_item"], child: "no" },
+  { name: "3 Swords, Tunics, Boots, and Shields", jp: '剣3種類・盾3種類・服3種類・靴3種類', types: ["sets", "spirit", "ice"], child: "no" },
+  { name: "4 Boss Keys", jp: 'ボス部屋のカギ4つ', types: ["dungeon_item", "claimcheck"], child: "no" },
+  { name: "10 Hearts", jp: 'ハート10個', types: ["hearts"], child: "yes" },
+  { name: "Ocarina of Time", jp: '時のオカリナ', types: ["atrade", "forest", "deku", "dc", "jabu"], child: "yes" }
+];

--- a/versions/v7/v7.0/generator.js
+++ b/versions/v7/v7.0/generator.js
@@ -1,0 +1,243 @@
+//NOTICE: As of version 6, this script will only generate cards correctly for Ocarina of Time bingo
+//and as shuch should be saved alongside the regular bingo script.
+ootBingoGenerator = function (bingoList, opts) {
+	if (!opts) opts = {};
+	var LANG = opts.lang || 'name';
+	var SEED = opts.seed || Math.ceil(999999 * Math.random()).toString();
+	Math.seedrandom(SEED);
+	var MODE = opts.mode || 'normal';
+
+	//giuocob 16-8-12: lineCheckList[] has been replaced to allow for removal of all-child rows
+	//Note: the rowElements relation is simply the inverse of the rowCheckList relation
+	var rowElements = {};
+	rowElements["row1"] = [1, 2, 3, 4, 5];
+	rowElements["row2"] = [6, 7, 8, 9, 10];
+	rowElements["row3"] = [11, 12, 13, 14, 15];
+	rowElements["row4"] = [16, 17, 18, 19, 20];
+	rowElements["row5"] = [21, 22, 23, 24, 25];
+	rowElements["col1"] = [1, 6, 11, 16, 21];
+	rowElements["col2"] = [2, 7, 12, 17, 22];
+	rowElements["col3"] = [3, 8, 13, 18, 23];
+	rowElements["col4"] = [4, 9, 14, 19, 24];
+	rowElements["col5"] = [5, 10, 15, 20, 25];
+	rowElements["tlbr"] = [1, 7, 13, 19, 25];
+	rowElements["bltr"] = [5, 9, 13, 17, 21];
+
+	//Given an object that maps keys to flat arrays, invert said object
+	function invertObject(obj) {
+		var ret = {};
+		Object.keys(obj).forEach(function (key) {
+			obj[key].forEach(function (item) {
+				if (!ret[item]) ret[item] = [];
+				ret[item].push(key);
+			});
+		});
+		return ret;
+	}
+
+	rowCheckList = invertObject(rowElements);
+
+function mirror(i) {
+	if      (i == 0) { i = 4; }
+	else if (i == 1) { i = 3; }
+	else if (i == 3) { i = 1; }
+	else if (i == 4) { i = 0; }
+	return i;
+}
+
+function difficulty(i) {
+	// To create the magic square we need 2 random orderings of the numbers 0, 1, 2, 3, 4.
+	// The following creates those orderings and calls them Table5 and Table1
+	
+	var Num3 = SEED%1000;	// Table5 will use the ones, tens, and hundreds digits.
+
+	var Rem8 = Num3%8;
+	var Rem4 = Math.floor(Rem8/2);
+	var Rem2 = Rem8%2;
+	var Rem5 = Num3%5;
+	var Rem3 = Num3%3;	// Note that Rem2, Rem3, Rem4, and Rem5 are mathematically independent.
+	var RemT = Math.floor(Num3/120);	// This is between 0 and 8		
+
+	// The idea is to begin with an array containing a single number, 0.
+	// Each number 1 through 4 is added in a random spot in the array's current size.
+	// The result - the numbers 0 to 4 are in the array in a random (and uniform) order.
+	var Table5 = [0];
+	Table5.splice(Rem2, 0, 1);
+	Table5.splice(Rem3, 0, 2);
+	Table5.splice(Rem4, 0, 3);
+	Table5.splice(Rem5, 0, 4);
+
+	Num3 = Math.floor(SEED/1000);	// Table1 will use the next 3 digits.
+	Num3 = Num3%1000;
+
+	Rem8 = Num3%8;
+	Rem4 = Math.floor(Rem8/2);
+	Rem2 = Rem8%2;
+	Rem5 = Num3%5;
+	Rem3 = Num3%3;
+	RemT = RemT * 8 + Math.floor(Num3/120);	 // This is between 0 and 64.
+
+	var Table1 = [0];
+	Table1.splice(Rem2, 0, 1);
+	Table1.splice(Rem3, 0, 2);
+	Table1.splice(Rem4, 0, 3);
+	Table1.splice(Rem5, 0, 4);
+
+	i--;
+	RemT = RemT%5;		//  Between 0 and 4, fairly uniformly.
+	x = (i+RemT)%5;		//  RemT is horizontal shift to put any diagonal on the main diagonal.
+	y = Math.floor(i/5);
+
+	// The Tables are set into a single magic square template
+	// Some are the same up to some rotation, reflection, or row permutation.
+	// However, all genuinely different magic squares can arise in this fashion.
+	var e5 = Table5[(x + 3*y)%5];
+	var e1 = Table1[(3*x + y)%5];
+
+	// Table5 controls the 5* part and Table1 controls the 1* part.
+	value = 5*e5 + e1;
+
+	if (MODE == "short") { value = Math.floor(value/2); } // if short mode, limit difficulty
+    	else if (MODE == "long") { value = Math.floor((value + 25) / 2); }
+    	value++;
+console.debug(value);
+	return value;
+}
+
+function getShuffledGoals(difficulty)
+{
+	var newArray = bingoList[difficulty].slice();
+	for(var i=0;i<newArray.length;i++)
+	{
+		var randElement = Math.floor(Math.random()*(i+1));
+		var temp = newArray[i];
+		newArray[i] = newArray[randElement];
+		newArray[randElement] = temp;
+	}
+	return newArray;
+}
+  
+
+
+function checkLine(i, testsquare)
+{
+	var typesA = testsquare.types;
+	var synergy = 0;
+	var rows = rowCheckList[i], elements = [];
+	var childCount = 0;
+	for(var k=0;k<rows.length;k++)
+	{
+		elements = rowElements[rows[k]];
+		childCount = 0;
+		for(var m=0;m<elements.length;m++)
+		{
+			var typesB = bingoBoard[elements[m]].types;
+			if(typeof typesB != 'undefined')
+			{
+				for(var n=0;n<typesA.length;n++)
+				{
+					for(var p=0;p<typesB.length;p++)
+					{
+						if(typesA[n] == typesB[p])
+						{
+							synergy++; //if match increase
+							if(n==0) { synergy++ }; //if main type increase
+							if(p==0) { synergy++ }; //if main type increase
+						}
+					}
+				}
+			}
+			if(bingoBoard[elements[m]].child == "yes")
+			{
+				childCount++;
+			}
+		}
+		//Remove child-only rows, remove adult goals from short
+		if(MODE == "short")
+		{
+			if(testsquare.child == "no")
+			{
+				childCount--;
+			}
+			console.debug(rows[k]);
+			console.debug(childCount);
+			if(childCount < 5)
+			{
+				synergy += 3;
+			}
+		}
+		else
+		{
+			if(testsquare.child == "yes")
+			{
+				childCount++;
+			}
+			if(childCount > 4)
+			{
+				synergy += 3;
+			}
+		}
+	}
+	return synergy;
+}
+
+
+
+  var bingoBoard = []; //the board itself stored as an array first
+  for (var i=1;i<=25;i++) {
+	if(MODE == "short")
+	{
+        bingoBoard[i] = {difficulty: difficulty(i), child: "yes"};
+    }
+    else
+    {
+		bingoBoard[i] = {difficulty: difficulty(i), child: "no"};
+	}
+  }                                          // in order 1-25
+  
+    //Populate the bingo board in the array
+    //giuocob 16-8-12: changed this section to:
+    //1. Support uniform goal selection by shuffling arrays before checking goals
+    //2. Remove all child rows by checking child tag
+    //3. If no goal is suitable, instead of choosing goal with lowest synergy, now next difficulty up is checked
+    //   Silly 26-difficulty goals have been added that appear only if the generator runs out of viable goals
+    //   (aka a defect in the goal list)
+    for(var i=1;i<=25;i++)
+    {
+		var getDifficulty = bingoBoard[i].difficulty;
+		var goalArray = getShuffledGoals(getDifficulty);
+		var j=0, synergy=0, currentObj=null, minSynObj=null;
+		do
+		{
+			currentObj = goalArray[j];
+			synergy = checkLine(i,currentObj);
+			if(minSynObj == null || synergy < minSynObj.synergy)
+			{
+				minSynObj = {synergy: synergy, value: currentObj};
+			}
+			j++;
+			if(j >= goalArray.length)
+			{
+				getDifficulty++;
+				if(getDifficulty > 25)
+				{
+					break;
+				}
+				else
+				{
+				    goalArray = getShuffledGoals(getDifficulty);
+				    j = 0;
+				}
+			}
+		} while(synergy != 0);   //Perhaps increase to 1 if difficulty increases happen too often
+		
+    
+    bingoBoard[i].types = minSynObj.value.types;
+    bingoBoard[i].name = minSynObj.value[LANG] || minSynObj.value.name;
+    bingoBoard[i].child = minSynObj.value.child;
+    bingoBoard[i].synergy = minSynObj.synergy;
+  }
+  
+  return bingoBoard;
+  
+}

--- a/versions/v7/v7.0/goal-list.js
+++ b/versions/v7/v7.0/goal-list.js
@@ -1,0 +1,243 @@
+﻿//Version 7 of the Ocarina of Time bingo goal list
+//Overview of changes from v6:
+//   Removed all adult trade item goals (pocket cucco, cojiro...claim check)
+//   Lowered the difficulty of several broken goals including spirit skulltulas, botw skulltulas, frog's heart piece
+//   Raised the difficulties of some goals in fire and spirit to make them more viable
+//   Added 'At least 4 skulltulas in Water Temple' as difficulty 19 goal
+//   Fixed some synergies, especially those pertaining to 'zl' and 'quiver'
+//   Added child designation to some borderline child-possible goals
+//   Rearranged goals slightly so similar goals are not in the same difficulty tier
+
+var bingoList = [];
+bingoList["info"] = {
+  version: "v7.0"
+};
+bingoList[1] = [
+  { name: "Bottled Fish", jp: 'ビン(魚)', types: ["bottle"], child: "yes" },
+  { name: "Bottled Fairy", jp: 'ビン(妖精)', types: ["bottle"], child: "yes" },
+  { name: "Red Potion", jp: '赤いクスリ', types: ["bottle"], child: "yes" },
+  { name: "Green Potion", jp: '緑のクスリ', types: ["bottle"], child: "yes" },
+  { name: "Bottled Poe", jp: 'ビン(ポウ)', types: ["bottle"], child: "yes" },
+  { name: "Lens of Truth", jp: 'まことのメガネ', types: ["botw"], child: "yes" }
+];
+bingoList[2] = [
+  { name: "Defeat a Skull Kid", jp: 'スタルキッド撃破', types: ["skullkid", "forest"], child: "no" },
+  { name: "Bullet Bag (50)", jp: 'デクのタネ袋(50)', types: ["bulletbag"], child: "yes" },
+  { name: "Adult's Wallet", jp: '大人のサイフ', types: ["wallet", "skulltula", "atrade"], child: "yes" },
+  { name: "Map & Compass in Deku Tree", jp: 'デクの樹様の中のマップとコンパス', types: ["deku", "dungeon_item"], child: "yes" },
+  { name: "At least 30 Deku Nuts", jp: 'デクの実30個以上', types: ["nuts", "forest"], child: "yes" }
+];
+bingoList[3] = [
+  { name: "Fairy Slingshot", jp: '妖精のパチンコ', types: ["bulletbag", "deku"], child: "yes" },
+  { name: "Map & Compass in Dodongo's Cavern", jp: 'ドドンゴの洞窟のマップとコンパス', types: ["dc", "dungeon_item"], child: "yes" },
+  { name: "Ruto's Letter", jp: 'ルトの手紙', types: ["ruto"], child: "yes" },
+  { name: "Map & Compass in Bottom of the Well", jp: '井戸の底のマップとコンパス', types: ["botw", "dungeon_item"], child: "yes" },
+  { name: "Black Gauntlets", jp: '黒のグローブ', types: ["strength", "bulletbag", "atrade"], child: "no" },
+  { name: "Goron Tunic", jp: 'ゴロンの服', types: ["sets", "dmc", "fire"], child: "no" }
+];
+bingoList[4] = [
+  { name: "Defeat King Dodongo", jp: 'キングドドンゴ撃破', types: ["dc"], child: "yes" },
+  { name: "3 Maps", jp: 'マップ3つ', types: ["dungeon_item"], child: "yes" },
+  { name: "Bullet Bag (40)", jp: 'デクのタネ袋(40)', types: ["bulletbag", "deku"], child: "yes" },
+  { name: "Bomb Bag (30)", jp: 'ボム袋(30)', types: ["bombbag", "dc", "atrade"], child: "yes" },
+  { name: "Minuet of Forest", jp: '森のメヌエット', types: ["forest", "songs"], child: "no" },
+  { name: "Zora Tunic", jp: 'ゾーラの服', types: ["sets", "ice"], child: "no" },
+  { name: "Bolero of Fire", jp: '炎のボレロ', types: ["dmc", "fire", "songs"], child: "no" }
+];
+bingoList[5] = [
+  { name: "3 Compasses", jp: 'コンパス3つ', types: ["dungeon_item"], child: "yes" },
+  { name: "Quiver (40)", jp: '矢立て(40)', types: ["atrade", "forest", "quiver"], child: "no" },
+  { name: "Map & Compass in Shadow Temple", jp: '闇の神殿のマップとコンパス', types: ["shadow", "dungeon_item"], child: "yes" },
+  { name: "Both heart pieces in Death Mountain Crater", jp: 'デスマウンテン火口のハートのかけら２つ', types: ["dmc", "fire", "hearts"], child: "yes" },
+  { name: "At least 3 songs", jp: '歌3つ以上', types: ["songs", "zl"], child: "yes" },
+  { name: "30 Deku Sticks", jp: 'デクの棒30本', types: ["atrade", "ctrade"], child: "yes" },
+  { name: "Cow in House", jp: '牛(リンクの家)', types: ["cow"], child: "no" }
+];
+bingoList[6] = [
+  { name: "Defeat Queen Gohma", jp: 'ゴーマ撃破', types: ["deku", "ganon"], child: "yes" },
+  { name: "Defeat all Lizalfos in Dodongo's Cavern", jp: 'ドドンゴの洞窟のリザルフォス全て撃破', types: ["dc"], child: "yes" },
+  { name: "Milk", jp: 'ロンロン牛乳', types: ["lonlon", "zl"], child: "yes" },
+  { name: "Beat the Deku Tree", jp: 'デクの樹様の中クリア', types: ["deku", "ganon"], child: "yes" },
+  { name: "Epona's Song", jp: 'エポナの歌', types: ["lonlon", "songs"], child: "yes" },
+  { name: "All 3 Kokiri Forest area Skulltulas", jp: 'コキリの森エリアの黄金のスタルチュラ３匹', types: ["skulltula"], child: "no" },
+  { name: "Beat Dodongo's Cavern", jp: 'ドドンゴの洞窟クリア', types: ["dc", "fortress"], child: "yes" }
+];
+bingoList[7] = [
+  { name: "Fill all 4 Bottle Slots", jp: '4つの空きビンスロットを全て埋める', types: ["bottle"], child: "yes" },
+  { name: "Fire Temple Boss Key", jp: '炎の神殿のボス部屋のカギ', types: ["fire", "dungeon_item"], child: "no" },
+  { name: "2 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ2つ', types: ["fortress"], child: "yes" },
+  { name: "Ice Arrows", jp: '氷の矢', types: ["fortress", "water"], child: "yes" },
+  { name: "Defeat Big Octo", jp: '大オクタ撃破', types: ["jabu"], child: "yes" },
+  { name: "3 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ3つ', types: ["fortress"], child: "yes" },
+  { name: "Defeat a White Wolfos", jp: 'ホワイトウルフォス撃破', types: ["ice", "fortress"], child: "yes" },
+  { name: "3 Tunics", jp: '服3種類', types: ["sets", "ice"], child: "no" }
+];
+bingoList[8] = [
+  { name: "Defeat Phantom Ganon", jp: 'ファントムガノン撃破', types: ["forest"], child: "yes" },
+  { name: "Map & Compass in Jabu-Jabu", jp: 'ジャブジャブ様のお腹のマップとコンパス', types: ["jabu", "dungeon_item"], child: "yes" },
+  { name: "Blue Fire", jp: '青い炎', types: ["ice", "bottle", "deku", "ganon"], child: "yes" },
+  { name: "5 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ5つ', types: ["fortress"], child: "yes" },
+  { name: "4 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ4つ', types: ["fortress"], child: "yes" },
+  { name: "37th heart piece (Child Fortress)", jp: '37番目のハートのかけら(子供のゲルドの砦)', types: ["fortress", "hearts"], child: "yes" },
+  { name: "Beat the Forest Temple", jp: '森の神殿クリア', types: ["forest"], child: "yes" },
+  { name: "6 Hearts", jp: 'ハート6つ', types: ["hearts"], child: "yes" },
+  { name: "Giant's Knife", jp: '巨人のナイフ', types: ["sets", "wallet", "dmc"], child: "no" },
+  { name: "Plant bean in Death Mountain Crater", jp: 'デスマウンテン火口の土にマメを植える', types: ["dmc", "beans"], child: "yes" }
+];
+bingoList[9] = [
+  { name: "Requiem of Spirit", jp: '魂のレクイエム', types: ["spirit", "songs"], child: "yes" },
+  { name: "Forest Medallion", jp: '森のメダル', types: ["forest", "lightarrow", "atrade"], child: "yes" },
+  { name: "At least 7 Magic Beans", jp: '魔法のマメ7つ以上', types: ["beans", "skulltula", "ctrade"], child: "yes" },
+  { name: "All 4 Lost Woods area Skulltulas", jp: '迷いの森エリアの黄金のスタルチュラ4匹', types: ["skulltula", "forest"], child: "no" },
+  { name: "Ice Cavern Heart Piece", jp: '氷の洞窟のハートのかけら', types: ["ice", "hearts"], child: "yes" },
+  { name: "Map & Compass in Ice Cavern", jp: '氷の洞窟のマップとコンパス', types: ["ice", "dungeon_item"], child: "no" },
+  { name: "All 3 Skulltulas in Ice Cavern", jp: '氷の洞窟の黄金のスタルチュラ3匹', types: ["ice", "skulltula"], child: "yes" },
+  { name: "Ganon's Castle Boss Key", jp: 'ガノン城のボス部屋のカギ', types: ["ganon", "deku", "dungeon_item"], child: "yes" },
+  { name: "6 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ6つ', types: ["fortress"], child: "yes" }
+];
+bingoList[10] = [
+  { name: "All 4 Skulltulas in Jabu-Jabu", jp: 'ジャブジャブ様のお腹の黄金のスタルチュラ4匹', types: ["jabu", "skulltula"], child: "yes" },
+  { name: "Both Gerudo's Fortress area Skulltulas", jp: 'ゲルドの砦の黄金のスタルチュラ2匹', types: ["skulltula", "fortress"], child: "no" },
+  { name: "All 4 Skulltulas in Deku Tree", jp: 'デクの樹様の中の黄金のスタルチュラ4匹', types: ["deku", "skulltula"], child: "yes" },
+  { name: "4 Maps", jp: 'マップ4つ', types: ["dungeon_item", "claimcheck"], child: "yes" },
+  { name: "4 Compasses", jp: 'コンパス4つ', types: ["dungeon_item"], child: "yes" },
+  { name: "Iron Boots", jp: 'ヘビーブーツ', types: ["ice", "sets"], child: "yes" },
+  { name: "Serenade of Water", jp: '水のセレナーデ', types: ["atrade", "ice", "songs"], child: "no" },
+  { name: "Prelude of Light", jp: '光のプレリュード', types: ["songs", "atrade", "forest"], child: "no" }
+];
+bingoList[11] = [
+  { name: "3 Boots", jp: '靴3種類', types: ["sets", "ice"], child: "yes" },
+  { name: "At least 4 songs", jp: '歌4つ以上', types: ["songs", "atrade", "zl"], child: "yes" },
+  { name: "Blue Potion", jp: '青いクスリ', types: ["atrade"], child: "no" },
+  { name: "Water Temple Boss Key", jp: '水の神殿のボス部屋のカギ', types: ["water", "fortress", "dungeon_item"], child: "no" },
+  { name: "Water Medallion", jp: '水のメダル', types: ["water", "lightarrow", "atrade"], child: "no" },
+  { name: "All 3 Skulltulas in Bottom of the Well", jp: '井戸の底の黄金のスタルチュラ3匹', types: ["botw", "skulltula"], child: "yes" }
+];
+bingoList[12] = [
+  { name: "All 5 Skulltulas in Dodongo's Cavern", jp: 'ドドンゴの洞窟の黄金のスタルチュラ5匹', types: ["dc", "skulltula"], child: "yes" },
+  { name: "At least 5 songs", jp: '歌5つ以上', types: ["songs", "atrade", "zl"], child: "yes" },
+  { name: "Defeat Barinade", jp: 'バリネード撃破', types: ["jabu"], child: "yes" },
+  { name: "Get Bombchu chest in Spirit Temple", jp: '魂の神殿のボムチュウ取得', types: ["spirit", "strength"], child: "yes" },
+  { name: "3 Swords & 3 Tunics", jp: '剣3種類と服3種類', types: ["sets", "ice"], child: "no" },
+  { name: "Bottled Big Poe", jp: 'ビン(ビッグポウ)', types: ["bigpoe", "quiver", "forest"], child: "no" }
+];
+bingoList[13] = [
+  { name: "Saria's Song", jp: 'サリアの歌', types: ["strength", "masks", "songs", "zl"], child: "yes" },
+  { name: "Defeat Morpha", jp: 'モーファ撃破', types: ["water"], child: "no" },
+  { name: "Beat Jabu-Jabu's Belly", jp: 'ジャブジャブ様のお腹クリア', types: ["jabu"], child: "yes" },
+  { name: "Keaton Mask", jp: 'キータンのお面', types: ["masks", "zl"], child: "yes" },
+  { name: "Giant's Wallet", jp: '巨人のサイフ', types: ["wallet", "atrade", "skulltula"], child: "yes" },
+  { name: "Beat the Water Temple", jp: '水の神殿クリア', types: ["water"], child: "no" },
+  { name: "All 8 Kakariko area Skulltulas", jp: 'カカリコ村エリアの黄金のスタルチュラ8匹', types: ["skulltula", "botw"], child: "no" }
+];
+bingoList[14] = [
+  { name: "Defeat both Flare Dancers", jp: 'フレアダンサー2体撃破', types: ["fire"], child: "no" },
+  { name: "Double Magic", jp: '魔力2倍', types: ["dmc", "zl"], child: "yes" },
+  { name: "At least 9 Magic Beans", jp: '魔法のマメ9つ以上', types: ["beans", "skulltula", "ctrade"], child: "yes" },
+  { name: "Map & Compass in Water Temple", jp: '水の神殿のマップとコンパス', types: ["water", "zl", "ice", "dungeon_item"], child: "no" },
+  { name: "Silver Gauntlets", jp: '銀のグローブ', types: ["strength", "spirit"], child: "yes" },
+  { name: "Double Defense", jp: '防御力2倍', types: ["zl", "ganon"], child: "no" },
+  { name: "At least 6 songs", jp: '歌6つ以上', types: ["songs", "atrade", "zl"], child: "no" },
+  { name: "Farore's Wind", jp: 'フロルの風', types: ["zl", "ice"], child: "yes" }
+];
+bingoList[15] = [
+  { name: "Mirror Shield", jp: 'ミラーシールド', types: ["sets", "spirit", "mirror"], child: "yes" },
+  { name: "Megaton Hammer", jp: 'メガトンハンマー', types: ["fire"], child: "no" },
+  { name: "7 Hearts", jp: 'ハート7つ', types: ["hearts"], child: "yes" },
+  { name: "3 Tunics & 3 Boots", jp: '服3種類と靴3種類', types: ["sets", "ice"], child: "no" },
+  { name: "Gerudo's Card", jp: 'ゲルドの会員証', types: ["fortress"], child: "yes" },
+  { name: "Map & Compass in Fire Temple", jp: '炎の神殿のマップとコンパス', types: ["fire", "dungeon_item"], child: "no" },
+  { name: "Fairy Bow", jp: '妖精の弓', types: ["forest", "quiver"], child: "no" },
+  { name: "Forest Temple Boss Key", jp: '森の神殿のボス部屋のカギ', types: ["forest", "dungeon_item", "claimcheck"], child: "no" }
+];
+bingoList[16] = [
+  { name: "5 Maps", jp: 'マップ5つ', types: ["dungeon_item", "claimcheck"], child: "yes" },
+  { name: "500 Rupees", jp: '500ルピー', types: ["wallet", "atrade", "skulltula"], child: "yes" },
+  { name: "All 4 Wasteland/ Colossus area Skulltulas", jp: '幻影の砂漠・巨大邪神像エリアの黄金のスタルチュラ4匹', types: ["skulltula", "spirit"], child: "no" },
+  { name: "Defeat Amy (Green Poe)", jp: 'エイミー撃破(緑のポウ)ｴ', types: ["forest", "quiver", "atrade"], child: "no" },
+  { name: "All 5 Skulltulas in Forest Temple", jp: '森の神殿の黄金のスタルチュラ5匹', types: ["forest", "skulltula"], child: "no" },
+  { name: "Map & Compass in Forest Temple", jp: '森の神殿のマップとコンパス', types: ["forest", "quiver", "dungeon_item"], child: "no" },
+  { name: "Skull Mask", jp: 'ドクロのお面', types: ["masks", "zl"], child: "yes" },
+  { name: "Treasure Chest Game Heart Piece", jp: '宝箱ゲームのハートのかけら', types: ["zl", "hearts"], child: "yes" },
+  { name: "Bombchu Bowling Heart Piece", jp: 'ボムチュウボウリングのハートのかけら', types: ["dc", "hearts"], child: "yes" }
+];
+bingoList[17] = [
+  { name: "Defeat Volvagia", jp: 'ヴァルバジア撃破', types: ["fire", "sets"], child: "no" },
+  { name: "Defeat Dark Link", jp: 'ダークリンク撃破', types: ["water", "ice"], child: "no" },
+  { name: "Both heart pieces in Lost Woods", jp: '迷いの森のハートのかけら２つ', types: ["strength", "masks", "songs", "zl", "hearts"], child: "yes" },
+  { name: "All 4 Lon-Lon Ranch area Skulltulas", jp: 'ロンロン牧場エリアの黄金のスタルチュラ4匹', types: ["jabu", "lonlon", "skulltula"], child: "yes" },
+  { name: "5 Compasses", jp: 'コンパス5つ', types: ["dungeon_item", "compass"], child: "yes" },
+  { name: "Shadow Temple Boss Key", jp: '闇の神殿のボス部屋のカギ', types: ["shadow", "zl", "dungeon_item"], child: "no" },
+  { name: "All 4 Gerudo Valley area Skulltulas", jp: 'ゲルドの谷エリアの黄金のスタルチュラ4匹', types: ["skulltula", "jabu"], child: "no" },
+  { name: "3 Boss Keys", jp: 'ボス部屋のカギ3つ', types: ["dungeon_item", "claimcheck"], child: "no" }
+];
+bingoList[18] = [
+  { name: "Beat the Fire Temple", jp: '炎の神殿クリア', types: ["fire", "sets", "forest"], child: "no" },
+  { name: "3 Swords & 3 Shields", jp: '剣3種類と盾3種類', types: ["sets", "spirit"], child: "no" },
+  { name: "7 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ7つ', types: ["fortress"], child: "no" },
+  { name: "Longshot", jp: 'ロングフック', types: ["water", "ice"], child: "no" },
+  { name: "Din's Fire", jp: 'ディンの炎', types: ["zl"], child: "yes" },
+  { name: "3 Swords & 3 Boots", jp: '剣3種類と靴3種類', types: ["sets", "ice"], child: "no" },
+  { name: "Get to the end of Fire Trial", jp: '炎の結界の最後の部屋に到達', types: ["ganon", "strength",], child: "no" },
+  { name: "Goron Bracelet", jp: 'ゴロンの腕輪', types: ["strength", "zl"], child: "yes" },
+  { name: "Golden Gauntlets", jp: '金のグローブ', types: ["strength", "ganon", "deku"], child: "yes" }
+];
+bingoList[19] = [
+  { name: "At least 4 Skulltulas in Water Temple", jp: '水の神殿の黄金のスタルチュラ4匹以上', types: ["water", "ice"], child: "no" },
+  { name: "Get to the end of Light Trial", jp: '光の結界の最後の部屋に到達', types: ["ganon", "zl", "strength"], child: "no" },
+  { name: "3 Shields & 3 Tunics", jp: '盾3種類と服3種類', types: ["sets", "spirit"], child: "no" },
+  { name: "All 5 Skulltulas in Fire Temple", jp: '炎の神殿の黄金のスタルチュラ5匹', types: ["fire", "skulltula"], child: "no" },
+  { name: "Stone of Agony", jp: 'もだえ石', types: ["agony", "skulltula"], child: "yes" },
+  { name: "Nayru's Love", jp: 'ネールの愛', types: ["spirit", "zl"], child: "yes" },
+  { name: "Spooky Mask", jp: 'こわそなお面', types: ["masks", "strength", "zl", "gerudo"], child: "yes" },
+  { name: "All 5 Skulltulas in Spirit Temple", jp: '魂の神殿の黄金のスタルチュラ5匹', types: ["spirit", "jabu", "skulltula", "atrade"], child: "yes" }
+];
+bingoList[20] = [
+  { name: "Bronze Gauntlets", jp: '銅のグローブ', types: ["strength", "bulletbag", "ganon", "atrade"], child: "no" },
+  { name: "6 Maps", jp: 'マップ6つ', types: ["dungeon_item", "claimcheck"], child: "yes" },
+  { name: "Frog's Heart Piece", jp: 'カエルのハートのかけら(嵐の歌)', types: ["songs", "forest", "hearts"], child: "no" },
+  { name: "Defeat Meg (purple Poe)", jp: 'メグ撃破(紫のポウ)', types: ["forest", "quiver"], child: "no" },
+  { name: "Spirit Temple Boss Key", jp: '魂の神殿のボス部屋のカギ', types: ["spirit", "lightarrow", "zl", "dungeon_item"], child: "no" },
+  { name: "Fire Arrow", jp: '炎の矢', types: ["water", "fire", "quiver"] },
+  { name: "All 8 Death Mountain area Skulltulas", jp: 'デスマウンテンエリアの黄金のスタルチュラ8匹', types: ["skulltula", "dmc"], child: "no" },
+  { name: "8 Hearts", jp: 'ハート8つ', types: ["hearts"], child: "yes" }
+];
+bingoList[21] = [
+  { name: "Defeat Bongo-Bongo", jp: 'ボンゴボンゴ撃破', types: ["shadow", "zl"], child: "no" },
+  { name: "6 Compasses", jp: 'コンパス6つ', types: ["dungeon_item"], child: "yes" },
+  { name: "8 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ8つ', types: ["fortress", "water"], child: "no" },
+  { name: "Defeat Nabooru-Knuckle", jp: 'アイアンナック(ナボール)撃破', types: ["spirit"], child: "no" },
+  { name: "Get to the end of Water Trial", jp: '水の結界の最後の部屋に到達', types: ["ganon", "fire", "lightarrow"] },
+  { name: "Both Hyrule Field area Skulltulas", jp: 'ハイラル平原エリアの黄金のスタルチュラ2匹', types: ["skulltula", "zl", "water"], child: "yes" },
+  { name: "At least 8 songs", jp: '歌8つ以上', types: ["songs", "atrade", "zl"], child: "no" }
+];
+bingoList[22] = [
+  { name: "All 4 Market area Skulltulas", jp: '城下町エリアの黄金のスタルチュラ4匹', types: ["skulltula", "forest"], child: "no" },
+  { name: "Quiver (50)", jp: '矢立て(50)', types: ["quiver", "fortress"], child: "no" },
+  { name: "All 5 Skulltulas in Shadow Temple", jp: '闇の神殿の黄金のスタルチュラ5匹', types: ["shadow", "skulltula", "zl"], child: "no" },
+  { name: "Blue Gauntlets", jp: '青のグローブ', types: ["spirit", "strength", "bulletbag", "atrade"], child: "no" },
+  { name: "Light Arrows", jp: '光の矢', types: ["lightarrow", "atrade"], child: "no" },
+  { name: "Get to the end of Shadow Trial", jp: '闇の結界の最後の部屋に到達', types: ["ganon", "fire"], child: "no" },
+  { name: "Beat the Shadow Temple", jp: '闇の神殿クリア', types: ["shadow", "zl"], child: "no" }
+];
+bingoList[23] = [
+  { name: "Map & Compass in Spirit Temple", jp: '魂の神殿のマップとコンパス', types: ["spirit", "zl", "dungeon_item"], child: "yes" },
+  { name: "3 Shields & 3 Boots", jp: '盾3種類と靴3種類', types: ["sets", "spirit", "ice"], child: "yes" },
+  { name: "All 8 Zora's Domain area Skulltulas", jp: 'ゾーラの里エリアの黄金のスタルチュラ8匹', types: ["jabu", "strength", "ice"], child: "no" },
+  { name: "7 Maps", jp: 'マップ7つ', types: ["dungeon_item", "claimcheck"], child: "no" },
+  { name: "Get to the end of the Forest Trial", jp: '森の結界の最後の部屋に到達', types: ["ganon", "zl"], child: "yes" }
+];
+bingoList[24] = [
+  { name: "Defeat Twinrova", jp: 'ツインローバ撃破', types: ["spirit"], child: "no" },
+  { name: "9 Hearts", jp: 'ハート9つ', types: ["hearts"], child: "yes" },
+  { name: "Green Gauntlets", jp: '緑のグローブ', types: ["strength", "bulletbag", "zl", "atrade"], child: "no" },
+  { name: "At least 9 songs", jp: '歌9つ以上', types: ["songs", "atrade", "zl"], child: "no" },
+  { name: "All 5 Lake Hylia Skulltulas", jp: 'ハイリア湖畔エリアの黄金のスタルチュラ5匹', types: ["ice", "skulltula", "water"], child: "no" }
+];
+bingoList[25] = [
+  { name: "Beat the Spirit Temple", jp: '魂の神殿クリア', types: ["spirit"], child: "no" },
+  { name: "Bunny Hood", jp: 'ウサギずきん', types: ["masks", "strength", "zl", "beans"], child: "yes" },
+  { name: "All 5 Skulltulas in Water Temple", jp: '水の神殿の黄金のスタルチュラ5匹', types: ["water"], child: "no" },
+  { name: "Get to the end of Spirit Trial", jp: '魂の結界の最後の部屋に到達', types: ["ganon", "spirit", "quiver"], child: "no" },
+  { name: "7 Compasses", jp: 'コンパス7つ', types: ["dungeon_item"], child: "no" },
+];

--- a/versions/v7/v7.1/generator.js
+++ b/versions/v7/v7.1/generator.js
@@ -1,0 +1,290 @@
+//NOTICE: As of version 6, this script will only generate cards correctly for Ocarina of Time bingo
+//and as shuch should be saved alongside the regular bingo script.
+ootBingoGenerator = function (bingoList, opts) {
+	if (!opts) opts = {};
+	var LANG = opts.lang || 'name';
+	var SEED = opts.seed || Math.ceil(999999 * Math.random()).toString();
+	Math.seedrandom(SEED);
+	var MODE = opts.mode || 'normal';
+
+	//giuocob 16-8-12: lineCheckList[] has been replaced to allow for removal of all-child rows
+	//Note: the rowElements relation is simply the inverse of the rowCheckList relation
+	var rowElements = {};
+	rowElements["row1"] = [1, 2, 3, 4, 5];
+	rowElements["row2"] = [6, 7, 8, 9, 10];
+	rowElements["row3"] = [11, 12, 13, 14, 15];
+	rowElements["row4"] = [16, 17, 18, 19, 20];
+	rowElements["row5"] = [21, 22, 23, 24, 25];
+	rowElements["col1"] = [1, 6, 11, 16, 21];
+	rowElements["col2"] = [2, 7, 12, 17, 22];
+	rowElements["col3"] = [3, 8, 13, 18, 23];
+	rowElements["col4"] = [4, 9, 14, 19, 24];
+	rowElements["col5"] = [5, 10, 15, 20, 25];
+	rowElements["tlbr"] = [1, 7, 13, 19, 25];
+	rowElements["bltr"] = [5, 9, 13, 17, 21];
+
+	//Given an object that maps keys to flat arrays, invert said object
+	function invertObject(obj) {
+		var ret = {};
+		Object.keys(obj).forEach(function (key) {
+			obj[key].forEach(function (item) {
+				if (!ret[item]) ret[item] = [];
+				ret[item].push(key);
+			});
+		});
+		return ret;
+	}
+
+	rowCheckList = invertObject(rowElements);
+	
+function mirror(i) {
+	if      (i == 0) { i = 4; }
+	else if (i == 1) { i = 3; }
+	else if (i == 3) { i = 1; }
+	else if (i == 4) { i = 0; }
+	return i;
+}
+
+function difficulty(i) {
+	// To create the magic square we need 2 random orderings of the numbers 0, 1, 2, 3, 4.
+	// The following creates those orderings and calls them Table5 and Table1
+	
+	var Num3 = SEED%1000;	// Table5 will use the ones, tens, and hundreds digits.
+
+	var Rem8 = Num3%8;
+	var Rem4 = Math.floor(Rem8/2);
+	var Rem2 = Rem8%2;
+	var Rem5 = Num3%5;
+	var Rem3 = Num3%3;	// Note that Rem2, Rem3, Rem4, and Rem5 are mathematically independent.
+	var RemT = Math.floor(Num3/120);	// This is between 0 and 8		
+
+	// The idea is to begin with an array containing a single number, 0.
+	// Each number 1 through 4 is added in a random spot in the array's current size.
+	// The result - the numbers 0 to 4 are in the array in a random (and uniform) order.
+	var Table5 = [0];
+	Table5.splice(Rem2, 0, 1);
+	Table5.splice(Rem3, 0, 2);
+	Table5.splice(Rem4, 0, 3);
+	Table5.splice(Rem5, 0, 4);
+
+	Num3 = Math.floor(SEED/1000);	// Table1 will use the next 3 digits.
+	Num3 = Num3%1000;
+
+	Rem8 = Num3%8;
+	Rem4 = Math.floor(Rem8/2);
+	Rem2 = Rem8%2;
+	Rem5 = Num3%5;
+	Rem3 = Num3%3;
+	RemT = RemT * 8 + Math.floor(Num3/120);	 // This is between 0 and 64.
+
+	var Table1 = [0];
+	Table1.splice(Rem2, 0, 1);
+	Table1.splice(Rem3, 0, 2);
+	Table1.splice(Rem4, 0, 3);
+	Table1.splice(Rem5, 0, 4);
+
+	i--;
+	RemT = RemT%5;		//  Between 0 and 4, fairly uniformly.
+	x = (i+RemT)%5;		//  RemT is horizontal shift to put any diagonal on the main diagonal.
+	y = Math.floor(i/5);
+
+	// The Tables are set into a single magic square template
+	// Some are the same up to some rotation, reflection, or row permutation.
+	// However, all genuinely different magic squares can arise in this fashion.
+	var e5 = Table5[(x + 3*y)%5];
+	var e1 = Table1[(3*x + y)%5];
+
+	// Table5 controls the 5* part and Table1 controls the 1* part.
+	value = 5*e5 + e1;
+
+	if (MODE == "short") { value = Math.floor(value/2); } // if short mode, limit difficulty
+    	else if (MODE == "long") { value = Math.floor((value + 25) / 2); }
+    	value++;
+	return value;
+}
+
+//Uniformly shuffles an array (note: the original array will be changed)
+function shuffle(toShuffle)
+{
+	for(var i=0;i<toShuffle.length;i++)
+	{
+		var randElement = Math.floor(Math.random()*(i+1));
+		var temp = toShuffle[i];
+		toShuffle[i] = toShuffle[randElement];
+		toShuffle[randElement] = temp;
+	}
+}
+
+//Get a uniformly shuffled array of all the goals of a given difficulty tier
+function getShuffledGoals(difficulty)
+{
+	var newArray = bingoList[difficulty].slice();
+	shuffle(newArray);
+	return newArray;
+}
+
+//Given a difficulty as an argument, find the square that contains that difficulty
+function getDifficultyIndex(difficulty)
+{
+	for(var i=1;i<=25;i++)
+	{
+		if(bingoBoard[i].difficulty == difficulty)
+		{
+			return i;
+		}
+	}
+	return 0;
+}
+  
+
+
+function checkLine(i, testsquare)
+{
+	var typesA = testsquare.types;
+	var synergy = 0;
+	var rows = rowCheckList[i], elements = [];
+	var childCount = 0;
+	for(var k=0;k<rows.length;k++)
+	{
+		elements = rowElements[rows[k]];
+		childCount = 0;
+		for(var m=0;m<elements.length;m++)
+		{
+			var typesB = bingoBoard[elements[m]].types;
+			if(typeof typesB != 'undefined')
+			{
+				for(var n=0;n<typesA.length;n++)
+				{
+					for(var p=0;p<typesB.length;p++)
+					{
+						if(typesA[n] == typesB[p])
+						{
+							synergy++; //if match increase
+							if(n==0) { synergy++ }; //if main type increase
+							if(p==0) { synergy++ }; //if main type increase
+						}
+					}
+				}
+			}
+			if(bingoBoard[elements[m]].child == "yes")
+			{
+				childCount++;
+			}
+		}
+		//Remove child-only rows, remove adult goals from short
+		if(MODE == "short")
+		{
+			if(testsquare.child == "no")
+			{
+				childCount--;
+			}
+			console.debug(rows[k]);
+			console.debug(childCount);
+			if(childCount < 5)
+			{
+				synergy += 3;
+			}
+		}
+		else
+		{
+			if(testsquare.child == "yes")
+			{
+				childCount++;
+			}
+			if(childCount > 4)
+			{
+				synergy += 3;
+			}
+		}
+	}
+	return synergy;
+}
+
+
+
+  var bingoBoard = []; //the board itself stored as an array first
+  for (var i=1;i<=25;i++) {
+	if(MODE == "short")
+	{
+        bingoBoard[i] = {difficulty: difficulty(i), child: "yes"};
+    }
+    else
+    {
+		bingoBoard[i] = {difficulty: difficulty(i), child: "no"};
+	}
+  }                                          // in order 1-25
+  
+  
+    //giuocob 19-2-13: bingoBoard is no longer populated left to right:
+    //It is now populated mostly randomly, with high difficult goals and
+    //goals on the diagonals out in front
+    var populationOrder = [];
+    populationOrder[1] = 13;   //Populate center first
+    var diagonals = [1,7,19,25,5,9,17,21];
+    shuffle(diagonals);
+    populationOrder = populationOrder.concat(diagonals);   //Next populate diagonals
+    var nondiagonals = [2,3,4,6,8,10,11,12,14,15,16,18,20,22,23,24];
+    shuffle(nondiagonals);
+    populationOrder = populationOrder.concat(nondiagonals);   //Finally add the rest of the squares
+    //Lastly, find location of difficulty 23,24,25 elements and put them out front
+    for(var k=23;k<=25;k++)
+    {
+		var currentSquare = getDifficultyIndex(k);
+		if(currentSquare == 0) continue;
+		for(var i=1;i<25;i++)
+		{
+			if(populationOrder[i] == currentSquare)
+			{
+				populationOrder.splice(i,1);
+				break;
+			}
+		}
+		populationOrder.splice(1,0,currentSquare);
+	}
+
+    
+  
+    //Populate the bingo board in the array
+    //giuocob 16-8-12: changed this section to:
+    //1. Support uniform goal selection by shuffling arrays before checking goals
+    //2. Remove all child rows by checking child tag
+    //3. If no goal is suitable, instead of choosing goal with lowest synergy, now next difficulty up is checked
+    for(var i=1;i<=25;i++)
+    {
+		var sq = populationOrder[i];
+		var getDifficulty = bingoBoard[sq].difficulty;
+		var goalArray = getShuffledGoals(getDifficulty);
+		var j=0, synergy=0, currentObj=null, minSynObj=null;
+		do
+		{
+			currentObj = goalArray[j];
+			synergy = checkLine(sq,currentObj);
+			if(minSynObj == null || synergy < minSynObj.synergy)
+			{
+				minSynObj = {synergy: synergy, value: currentObj};
+			}
+			j++;
+			if(j >= goalArray.length)
+			{
+				getDifficulty++;
+				if(getDifficulty > 25)
+				{
+					break;
+				}
+				else
+				{
+				    goalArray = getShuffledGoals(getDifficulty);
+				    j = 0;
+				}
+			}
+		} while(synergy != 0);   //Perhaps increase to 1 if difficulty increases happen too often
+		
+    
+    bingoBoard[sq].types = minSynObj.value.types;
+    bingoBoard[sq].name = minSynObj.value[LANG] || minSynObj.value.name;
+    bingoBoard[sq].child = minSynObj.value.child;
+    bingoBoard[sq].synergy = minSynObj.synergy;
+  }
+
+  return bingoBoard;
+}

--- a/versions/v7/v7.1/goal-list.js
+++ b/versions/v7/v7.1/goal-list.js
@@ -1,0 +1,240 @@
+﻿//Version 7.1 of the Ocarina of Time bingo goal list
+//Overview of changes from v6:
+//   Removed all adult trade item goals (pocket cucco, cojiro...claim check)
+//   Lowered the difficulty of several broken goals including spirit skulltulas, botw skulltulas, frog's heart piece
+//   Raised the difficulties of some goals in fire and spirit to make them more viable
+//   Added 'At least 3 skulltulas in Water Temple' as difficulty 16 goal
+//   Added 'Free all 9 gorons in Fire Temple' as difficulty 21 goal
+//   Fixed some synergies, especially those pertaining to 'zl' and 'quiver'
+//   Added child designation to some borderline child-possible goals
+//   Rearranged goals slightly so similar goals are not in the same difficulty tier
+
+var bingoList = [];
+bingoList["info"] = {
+  version: "v7.1"
+};
+bingoList[1] = [
+  { name: "Bottled Fish", jp: 'ビン(魚)', types: ["bottle"], child: "yes" },
+  { name: "Bottled Fairy", jp: 'ビン(妖精)', types: ["bottle"], child: "yes" },
+  { name: "Red Potion", jp: '赤いクスリ', types: ["bottle"], child: "yes" },
+  { name: "Green Potion", jp: '緑のクスリ', types: ["bottle"], child: "yes" },
+  { name: "Bottled Poe", jp: 'ビン(ポウ)', types: ["bottle"], child: "yes" },
+  { name: "Lens of Truth", jp: 'まことのメガネ', types: ["botw"], child: "yes" }
+];
+bingoList[2] = [
+  { name: "Defeat a Skull Kid", jp: 'スタルキッド撃破', types: ["skullkid", "forest"], child: "no" },
+  { name: "Bullet Bag (50)", jp: 'デクのタネ袋(50)', types: ["bulletbag"], child: "yes" },
+  { name: "Adult's Wallet", jp: '大人のサイフ', types: ["wallet", "skulltula", "atrade"], child: "yes" },
+  { name: "Map & Compass in Deku Tree", jp: 'デクの樹様の中のマップとコンパス', types: ["deku", "dungeon_item"], child: "yes" },
+  { name: "At least 30 Deku Nuts", jp: 'デクの実30個以上', types: ["nuts", "forest"], child: "yes" }
+];
+bingoList[3] = [
+  { name: "Fairy Slingshot", jp: '妖精のパチンコ', types: ["bulletbag", "deku"], child: "yes" },
+  { name: "Map & Compass in Dodongo's Cavern", jp: 'ドドンゴの洞窟のマップとコンパス', types: ["dc", "dungeon_item"], child: "yes" },
+  { name: "Ruto's Letter", jp: 'ルトの手紙', types: ["ruto"], child: "yes" },
+  { name: "Map & Compass in Bottom of the Well", jp: '井戸の底のマップとコンパス', types: ["botw", "dungeon_item"], child: "yes" },
+  { name: "Black Gauntlets", jp: '黒のグローブ', types: ["strength", "bulletbag", "atrade"], child: "no" },
+  { name: "Goron Tunic", jp: 'ゴロンの服', types: ["sets", "dmc", "fire"], child: "no" }
+];
+bingoList[4] = [
+  { name: "Defeat King Dodongo", jp: 'キングドドンゴ撃破', types: ["dc"], child: "yes" },
+  { name: "Bullet Bag (40)", jp: 'デクのタネ袋(40)', types: ["bulletbag", "deku"], child: "yes" },
+  { name: "Bomb Bag (30)", jp: 'ボム袋(30)', types: ["bombbag", "dc", "atrade"], child: "yes" },
+  { name: "Minuet of Forest", jp: '森のメヌエット', types: ["forest", "songs"], child: "no" },
+  { name: "Zora Tunic", jp: 'ゾーラの服', types: ["sets", "ice"], child: "no" },
+  { name: "Bolero of Fire", jp: '炎のボレロ', types: ["dmc", "fire", "songs"], child: "no" }
+];
+bingoList[5] = [
+  { name: "Quiver (40)", jp: '矢立て(40)', types: ["atrade", "forest", "quiver"], child: "no" },
+  { name: "Map & Compass in Shadow Temple", jp: '闇の神殿のマップとコンパス', types: ["shadow", "dungeon_item"], child: "yes" },
+  { name: "Both heart pieces in Death Mountain Crater", jp: 'デスマウンテン火口のハートのかけら２つ', types: ["dmc", "fire", "hearts"], child: "yes" },
+  { name: "At least 3 songs", jp: '歌3つ以上', types: ["songs", "zl"], child: "yes" },
+  { name: "30 Deku Sticks", jp: 'デクの棒30本', types: ["atrade", "ctrade"], child: "yes" },
+  { name: "Cow in House", jp: '牛(リンクの家)', types: ["cow"], child: "no" }
+];
+bingoList[6] = [
+  { name: "4 Maps", jp: 'マップ4つ', types: ["dungeon_item", "claimcheck"], child: "yes" },
+  { name: "Defeat Queen Gohma", jp: 'ゴーマ撃破', types: ["deku", "ganon"], child: "yes" },
+  { name: "Defeat all Lizalfos in Dodongo's Cavern", jp: 'ドドンゴの洞窟のリザルフォス全て撃破', types: ["dc"], child: "yes" },
+  { name: "Milk", jp: 'ロンロン牛乳', types: ["lonlon", "zl"], child: "yes" },
+  { name: "Beat the Deku Tree", jp: 'デクの樹様の中クリア', types: ["deku", "ganon"], child: "yes" },
+  { name: "Epona's Song", jp: 'エポナの歌', types: ["lonlon", "songs"], child: "yes" },
+  { name: "All 3 Kokiri Forest area Skulltulas", jp: 'コキリの森エリアの黄金のスタルチュラ３匹', types: ["skulltula"], child: "no" },
+  { name: "Beat Dodongo's Cavern", jp: 'ドドンゴの洞窟クリア', types: ["dc", "fortress"], child: "yes" }
+];
+bingoList[7] = [
+  { name: "4 Compasses", jp: 'コンパス4つ', types: ["dungeon_item"], child: "yes" },
+  { name: "Fill all 4 Bottle Slots", jp: '4つの空きビンスロットを全て埋める', types: ["bottle"], child: "yes" },
+  { name: "Fire Temple Boss Key", jp: '炎の神殿のボス部屋のカギ', types: ["fire", "dungeon_item"], child: "no" },
+  { name: "Ice Arrows", jp: '氷の矢', types: ["fortress", "water"], child: "yes" },
+  { name: "Defeat Big Octo", jp: '大オクタ撃破', types: ["jabu"], child: "yes" },
+  { name: "3 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ3つ', types: ["fortress"], child: "yes" },
+  { name: "Defeat a White Wolfos", jp: 'ホワイトウルフォス撃破', types: ["ice", "fortress"], child: "yes" },
+  { name: "3 Tunics", jp: '服3種類', types: ["sets", "ice"], child: "no" }
+];
+bingoList[8] = [
+  { name: "Defeat Phantom Ganon", jp: 'ファントムガノン撃破', types: ["forest"], child: "yes" },
+  { name: "Map & Compass in Jabu-Jabu", jp: 'ジャブジャブ様のお腹のマップとコンパス', types: ["jabu", "dungeon_item"], child: "yes" },
+  { name: "Blue Fire", jp: '青い炎', types: ["ice", "bottle", "deku", "ganon"], child: "yes" },
+  { name: "5 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ5つ', types: ["fortress"], child: "yes" },
+  { name: "37th heart piece (Child Fortress)", jp: '37番目のハートのかけら(子供のゲルドの砦)', types: ["fortress", "hearts"], child: "yes" },
+  { name: "Beat the Forest Temple", jp: '森の神殿クリア', types: ["forest"], child: "yes" },
+  { name: "6 Hearts", jp: 'ハート6つ', types: ["hearts"], child: "yes" },
+  { name: "Giant's Knife", jp: '巨人のナイフ', types: ["sets", "wallet", "dmc"], child: "no" },
+  { name: "Plant bean in Death Mountain Crater", jp: 'デスマウンテン火口の土にマメを植える', types: ["dmc", "beans"], child: "yes" }
+];
+bingoList[9] = [
+  { name: "Requiem of Spirit", jp: '魂のレクイエム', types: ["spirit", "songs"], child: "yes" },
+  { name: "Forest Medallion", jp: '森のメダル', types: ["forest", "lightarrow", "atrade"], child: "yes" },
+  { name: "At least 7 Magic Beans", jp: '魔法のマメ7つ以上', types: ["beans", "skulltula", "ctrade"], child: "yes" },
+  { name: "All 4 Lost Woods area Skulltulas", jp: '迷いの森エリアの黄金のスタルチュラ4匹', types: ["skulltula", "forest"], child: "no" },
+  { name: "Ice Cavern Heart Piece", jp: '氷の洞窟のハートのかけら', types: ["ice", "hearts"], child: "yes" },
+  { name: "Map & Compass in Ice Cavern", jp: '氷の洞窟のマップとコンパス', types: ["ice", "dungeon_item"], child: "no" },
+  { name: "All 3 Skulltulas in Ice Cavern", jp: '氷の洞窟の黄金のスタルチュラ3匹', types: ["ice", "skulltula"], child: "yes" },
+  { name: "Ganon's Castle Boss Key", jp: 'ガノン城のボス部屋のカギ', types: ["ganon", "deku", "dungeon_item"], child: "yes" },
+  { name: "6 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ6つ', types: ["fortress"], child: "yes" }
+];
+bingoList[10] = [
+  { name: "All 4 Skulltulas in Jabu-Jabu", jp: 'ジャブジャブ様のお腹の黄金のスタルチュラ4匹', types: ["jabu", "skulltula"], child: "yes" },
+  { name: "Both Gerudo's Fortress area Skulltulas", jp: 'ゲルドの砦の黄金のスタルチュラ2匹', types: ["skulltula", "fortress"], child: "no" },
+  { name: "All 4 Skulltulas in Deku Tree", jp: 'デクの樹様の中の黄金のスタルチュラ4匹', types: ["deku", "skulltula"], child: "yes" },
+  { name: "Iron Boots", jp: 'ヘビーブーツ', types: ["ice", "sets"], child: "yes" },
+  { name: "Serenade of Water", jp: '水のセレナーデ', types: ["atrade", "ice", "songs"], child: "no" },
+  { name: "Prelude of Light", jp: '光のプレリュード', types: ["songs", "atrade", "forest"], child: "no" }
+];
+bingoList[11] = [
+  { name: "5 Maps", jp: 'マップ5つ', types: ["dungeon_item", "claimcheck"], child: "yes" },
+  { name: "3 Boots", jp: '靴3種類', types: ["sets", "ice"], child: "yes" },
+  { name: "At least 4 songs", jp: '歌4つ以上', types: ["songs", "atrade", "zl"], child: "yes" },
+  { name: "Blue Potion", jp: '青いクスリ', types: ["atrade"], child: "no" },
+  { name: "Water Temple Boss Key", jp: '水の神殿のボス部屋のカギ', types: ["water", "fortress", "dungeon_item"], child: "no" },
+  { name: "Water Medallion", jp: '水のメダル', types: ["water", "lightarrow", "atrade"], child: "no" },
+  { name: "All 3 Skulltulas in Bottom of the Well", jp: '井戸の底の黄金のスタルチュラ3匹', types: ["botw", "skulltula"], child: "yes" }
+];
+bingoList[12] = [
+  { name: "All 5 Skulltulas in Dodongo's Cavern", jp: 'ドドンゴの洞窟の黄金のスタルチュラ5匹', types: ["dc", "skulltula"], child: "yes" },
+  { name: "At least 5 songs", jp: '歌5つ以上', types: ["songs", "atrade", "zl"], child: "yes" },
+  { name: "Defeat Barinade", jp: 'バリネード撃破', types: ["jabu"], child: "yes" },
+  { name: "Get Bombchu chest in Spirit Temple", jp: '魂の神殿のボムチュウ取得', types: ["spirit", "strength"], child: "yes" },
+  { name: "3 Swords & 3 Tunics", jp: '剣3種類と服3種類', types: ["sets", "ice", "wallet"], child: "no" },
+  { name: "Bottled Big Poe", jp: 'ビン(ビッグポウ)', types: ["quiver", "forest", "fortress"], child: "no" }
+];
+bingoList[13] = [
+  { name: "Saria's Song", jp: 'サリアの歌', types: ["strength", "masks", "songs", "zl"], child: "yes" },
+  { name: "Defeat Morpha", jp: 'モーファ撃破', types: ["water"], child: "no" },
+  { name: "Beat Jabu-Jabu's Belly", jp: 'ジャブジャブ様のお腹クリア', types: ["jabu"], child: "yes" },
+  { name: "Keaton Mask", jp: 'キータンのお面', types: ["masks", "zl"], child: "yes" },
+  { name: "Giant's Wallet", jp: '巨人のサイフ', types: ["wallet", "atrade", "skulltula"], child: "yes" },
+  { name: "Beat the Water Temple", jp: '水の神殿クリア', types: ["water"], child: "no" },
+  { name: "All 8 Kakariko area Skulltulas", jp: 'カカリコ村エリアの黄金のスタルチュラ8匹', types: ["skulltula", "botw"], child: "no" }
+];
+bingoList[14] = [
+  { name: "5 Compasses", jp: 'コンパス5つ', types: ["dungeon_item", "compass"], child: "yes" },
+  { name: "Defeat both Flare Dancers", jp: 'フレアダンサー2体撃破', types: ["fire"], child: "no" },
+  { name: "Double Magic", jp: '魔力2倍', types: ["dmc", "zl"], child: "yes" },
+  { name: "At least 9 Magic Beans", jp: '魔法のマメ9つ以上', types: ["beans", "skulltula", "ctrade"], child: "yes" },
+  { name: "Map & Compass in Water Temple", jp: '水の神殿のマップとコンパス', types: ["water", "zl", "ice", "dungeon_item"], child: "no" },
+  { name: "Silver Gauntlets", jp: '銀のグローブ', types: ["strength", "spirit"], child: "yes" },
+  { name: "Double Defense", jp: '防御力2倍', types: ["zl", "ganon"], child: "no" },
+  { name: "At least 6 songs", jp: '歌6つ以上', types: ["songs", "atrade", "zl"], child: "no" },
+  { name: "Farore's Wind", jp: 'フロルの風', types: ["zl", "ice"], child: "yes" }
+];
+bingoList[15] = [
+  { name: "Mirror Shield", jp: 'ミラーシールド', types: ["sets", "spirit", "mirror"], child: "yes" },
+  { name: "Megaton Hammer", jp: 'メガトンハンマー', types: ["fire"], child: "no" },
+  { name: "7 Hearts", jp: 'ハート7つ', types: ["hearts"], child: "yes" },
+  { name: "3 Tunics & 3 Boots", jp: '服3種類と靴3種類', types: ["sets", "ice"], child: "no" },
+  { name: "Gerudo's Card", jp: 'ゲルドの会員証', types: ["fortress"], child: "yes" },
+  { name: "Map & Compass in Fire Temple", jp: '炎の神殿のマップとコンパス', types: ["fire", "dungeon_item"], child: "no" },
+  { name: "Fairy Bow", jp: '妖精の弓', types: ["forest", "quiver"], child: "no" },
+  { name: "Forest Temple Boss Key", jp: '森の神殿のボス部屋のカギ', types: ["forest", "dungeon_item", "claimcheck"], child: "no" }
+];
+bingoList[16] = [
+  { name: "At least 3 Skulltulas in Water Temple", jp: '水の神殿の黄金のスタルチュラ3匹以上', types: ["water", "ice"], child: "no" },
+  { name: "500 Rupees", jp: '500ルピー', types: ["wallet", "atrade", "skulltula"], child: "yes" },
+  { name: "All 4 Wasteland/ Colossus area Skulltulas", jp: '幻影の砂漠・巨大邪神像エリアの黄金のスタルチュラ4匹', types: ["skulltula", "spirit"], child: "no" },
+  { name: "Defeat Amy (Green Poe)", jp: 'エイミー撃破(緑のポウ)ｴ', types: ["forest", "fortress", "quiver"], child: "no" },
+  { name: "All 5 Skulltulas in Forest Temple", jp: '森の神殿の黄金のスタルチュラ5匹', types: ["forest", "skulltula"], child: "no" },
+  { name: "Map & Compass in Forest Temple", jp: '森の神殿のマップとコンパス', types: ["forest", "quiver", "dungeon_item"], child: "no" },
+  { name: "Skull Mask", jp: 'ドクロのお面', types: ["masks", "zl"], child: "yes" },
+  { name: "Treasure Chest Game Heart Piece", jp: '宝箱ゲームのハートのかけら', types: ["zl", "hearts"], child: "yes" },
+  { name: "Bombchu Bowling Heart Piece", jp: 'ボムチュウボウリングのハートのかけら', types: ["dc", "hearts"], child: "yes" }
+];
+bingoList[17] = [
+  { name: "Defeat Volvagia", jp: 'ヴァルバジア撃破', types: ["fire", "sets"], child: "no" },
+  { name: "Defeat Dark Link", jp: 'ダークリンク撃破', types: ["water", "ice"], child: "no" },
+  { name: "Both heart pieces in Lost Woods", jp: '迷いの森のハートのかけら２つ', types: ["strength", "masks", "songs", "zl", "hearts"], child: "yes" },
+  { name: "All 4 Lon-Lon Ranch area Skulltulas", jp: 'ロンロン牧場エリアの黄金のスタルチュラ4匹', types: ["jabu", "lonlon", "skulltula"], child: "yes" },
+  { name: "Shadow Temple Boss Key", jp: '闇の神殿のボス部屋のカギ', types: ["shadow", "zl", "dungeon_item"], child: "no" },
+  { name: "All 4 Gerudo Valley area Skulltulas", jp: 'ゲルドの谷エリアの黄金のスタルチュラ4匹', types: ["skulltula", "gerudo", "jabu"], child: "no" },
+  { name: "3 Boss Keys", jp: 'ボス部屋のカギ3つ', types: ["dungeon_item", "claimcheck"], child: "no" }
+];
+bingoList[18] = [
+  { name: "Beat the Fire Temple", jp: '炎の神殿クリア', types: ["fire", "sets", "forest"], child: "no" },
+  { name: "3 Swords & 3 Shields", jp: '剣3種類と盾3種類', types: ["sets", "spirit"], child: "no" },
+  { name: "Longshot", jp: 'ロングフック', types: ["water", "ice"], child: "no" },
+  { name: "Din's Fire", jp: 'ディンの炎', types: ["zl"], child: "yes" },
+  { name: "3 Swords & 3 Boots", jp: '剣3種類と靴3種類', types: ["sets", "ice"], child: "no" },
+  { name: "Get to the end of Fire Trial", jp: '炎の結界の最後の部屋に到達', types: ["ganon", "strength",], child: "no" },
+  { name: "Goron Bracelet", jp: 'ゴロンの腕輪', types: ["strength", "zl"], child: "yes" },
+  { name: "Golden Gauntlets", jp: '金のグローブ', types: ["strength", "ganon", "deku"], child: "yes" }
+];
+bingoList[19] = [
+  { name: "Get to the end of Light Trial", jp: '光の結界の最後の部屋に到達', types: ["ganon", "zl", "strength"], child: "no" },
+  { name: "3 Shields & 3 Tunics", jp: '盾3種類と服3種類', types: ["sets", "spirit"], child: "no" },
+  { name: "All 5 Skulltulas in Fire Temple", jp: '炎の神殿の黄金のスタルチュラ5匹', types: ["fire", "skulltula"], child: "no" },
+  { name: "Stone of Agony", jp: 'もだえ石', types: ["skulltula", "wallet"], child: "yes" },
+  { name: "Nayru's Love", jp: 'ネールの愛', types: ["spirit", "zl"], child: "yes" },
+  { name: "Spooky Mask", jp: 'こわそなお面', types: ["masks", "strength", "zl", "gerudo"], child: "yes" },
+  { name: "All 5 Skulltulas in Spirit Temple", jp: '魂の神殿の黄金のスタルチュラ5匹', types: ["spirit", "jabu", "skulltula", "atrade"], child: "yes" }
+];
+bingoList[20] = [
+  { name: "Bronze Gauntlets", jp: '銅のグローブ', types: ["strength", "bulletbag", "ganon", "atrade"], child: "no" },
+  { name: "6 Maps", jp: 'マップ6つ', types: ["dungeon_item", "claimcheck"], child: "yes" },
+  { name: "Frog's Heart Piece", jp: 'カエルのハートのかけら(嵐の歌)', types: ["songs", "forest", "hearts"], child: "no" },
+  { name: "Defeat Meg (purple Poe)", jp: 'メグ撃破(紫のポウ)', types: ["forest", "quiver"], child: "no" },
+  { name: "Spirit Temple Boss Key", jp: '魂の神殿のボス部屋のカギ', types: ["spirit", "lightarrow", "zl", "dungeon_item"], child: "no" },
+  { name: "Fire Arrow", jp: '炎の矢', types: ["water", "fire", "quiver"] },
+  { name: "All 8 Death Mountain area Skulltulas", jp: 'デスマウンテンエリアの黄金のスタルチュラ8匹', types: ["skulltula", "dmc"], child: "no" },
+  { name: "8 Hearts", jp: 'ハート8つ', types: ["hearts"], child: "yes" }
+];
+bingoList[21] = [
+  { name: "Free all 9 gorons in Fire Temple", jp: '炎の神殿で９人のゴロンを全員救う', types: ["fire"], child: "no" },
+  { name: "Defeat Bongo-Bongo", jp: 'ボンゴボンゴ撃破', types: ["shadow", "zl"], child: "no" },
+  { name: "6 Compasses", jp: 'コンパス6つ', types: ["dungeon_item"], child: "yes" },
+  { name: "8 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ8つ', types: ["fortress", "water"], child: "no" },
+  { name: "Defeat Nabooru-Knuckle", jp: 'アイアンナック(ナボール)撃破', types: ["spirit"], child: "no" },
+  { name: "Get to the end of Water Trial", jp: '水の結界の最後の部屋に到達', types: ["ganon", "fire", "lightarrow"] },
+  { name: "Both Hyrule Field area Skulltulas", jp: 'ハイラル平原エリアの黄金のスタルチュラ2匹', types: ["skulltula", "zl", "water"], child: "yes" },
+  { name: "At least 8 songs", jp: '歌8つ以上', types: ["songs", "atrade", "zl"], child: "no" }
+];
+bingoList[22] = [
+  { name: "All 4 Market area Skulltulas", jp: '城下町エリアの黄金のスタルチュラ4匹', types: ["skulltula", "forest"], child: "no" },
+  { name: "Quiver (50)", jp: '矢立て(50)', types: ["quiver", "fortress"], child: "no" },
+  { name: "Blue Gauntlets", jp: '青のグローブ', types: ["spirit", "strength", "bulletbag", "atrade"], child: "no" },
+  { name: "Light Arrows", jp: '光の矢', types: ["lightarrow", "atrade"], child: "no" },
+  { name: "Get to the end of Shadow Trial", jp: '闇の結界の最後の部屋に到達', types: ["ganon", "fire"], child: "no" },
+  { name: "Beat the Shadow Temple", jp: '闇の神殿クリア', types: ["shadow", "zl"], child: "no" }
+];
+bingoList[23] = [
+  { name: "All 5 Skulltulas in Shadow Temple", jp: '闇の神殿の黄金のスタルチュラ5匹', types: ["shadow", "skulltula", "zl"], child: "no" },
+  { name: "Map & Compass in Spirit Temple", jp: '魂の神殿のマップとコンパス', types: ["spirit", "zl", "dungeon_item"], child: "yes" },
+  { name: "3 Shields & 3 Boots", jp: '盾3種類と靴3種類', types: ["sets", "spirit", "ice"], child: "yes" },
+  { name: "All 8 Zora's Domain area Skulltulas", jp: 'ゾーラの里エリアの黄金のスタルチュラ8匹', types: ["jabu", "strength", "ice"], child: "no" },
+  { name: "7 Maps", jp: 'マップ7つ', types: ["dungeon_item", "claimcheck"], child: "yes" },
+  { name: "Get to the end of the Forest Trial", jp: '森の結界の最後の部屋に到達', types: ["ganon", "zl"], child: "yes" }
+];
+bingoList[24] = [
+  { name: "Defeat Twinrova", jp: 'ツインローバ撃破', types: ["spirit"], child: "no" },
+  { name: "9 Hearts", jp: 'ハート9つ', types: ["hearts"], child: "yes" },
+  { name: "Green Gauntlets", jp: '緑のグローブ', types: ["strength", "bulletbag", "zl", "atrade"], child: "no" },
+  { name: "At least 9 songs", jp: '歌9つ以上', types: ["songs", "atrade", "zl"], child: "no" },
+  { name: "All 5 Lake Hylia Skulltulas", jp: 'ハイリア湖畔エリアの黄金のスタルチュラ5匹', types: ["ice", "skulltula", "water"], child: "no" }
+];
+bingoList[25] = [
+  { name: "Beat the Spirit Temple", jp: '魂の神殿クリア', types: ["spirit"], child: "no" },
+  { name: "Bunny Hood", jp: 'ウサギずきん', types: ["masks", "strength", "zl", "beans"], child: "yes" },
+  { name: "All 5 Skulltulas in Water Temple", jp: '水の神殿の黄金のスタルチュラ5匹', types: ["water"], child: "no" },
+  { name: "Get to the end of Spirit Trial", jp: '魂の結界の最後の部屋に到達', types: ["ganon", "spirit", "quiver"], child: "no" },
+  { name: "7 Compasses", jp: 'コンパス7つ', types: ["dungeon_item"], child: "no" },
+];

--- a/versions/v8/v8.0/generator.js
+++ b/versions/v8/v8.0/generator.js
@@ -1,0 +1,290 @@
+//NOTICE: As of version 6, this script will only generate cards correctly for Ocarina of Time bingo
+//and as shuch should be saved alongside the regular bingo script.
+ootBingoGenerator = function (bingoList, opts) {
+	if (!opts) opts = {};
+	var LANG = opts.lang || 'name';
+	var SEED = opts.seed || Math.ceil(999999 * Math.random()).toString();
+	Math.seedrandom(SEED);
+	var MODE = opts.mode || 'normal';
+
+	//giuocob 16-8-12: lineCheckList[] has been replaced to allow for removal of all-child rows
+	//Note: the rowElements relation is simply the inverse of the rowCheckList relation
+	var rowElements = {};
+	rowElements["row1"] = [1, 2, 3, 4, 5];
+	rowElements["row2"] = [6, 7, 8, 9, 10];
+	rowElements["row3"] = [11, 12, 13, 14, 15];
+	rowElements["row4"] = [16, 17, 18, 19, 20];
+	rowElements["row5"] = [21, 22, 23, 24, 25];
+	rowElements["col1"] = [1, 6, 11, 16, 21];
+	rowElements["col2"] = [2, 7, 12, 17, 22];
+	rowElements["col3"] = [3, 8, 13, 18, 23];
+	rowElements["col4"] = [4, 9, 14, 19, 24];
+	rowElements["col5"] = [5, 10, 15, 20, 25];
+	rowElements["tlbr"] = [1, 7, 13, 19, 25];
+	rowElements["bltr"] = [5, 9, 13, 17, 21];
+
+	//Given an object that maps keys to flat arrays, invert said object
+	function invertObject(obj) {
+		var ret = {};
+		Object.keys(obj).forEach(function (key) {
+			obj[key].forEach(function (item) {
+				if (!ret[item]) ret[item] = [];
+				ret[item].push(key);
+			});
+		});
+		return ret;
+	}
+
+	rowCheckList = invertObject(rowElements);
+	
+function mirror(i) {
+	if      (i == 0) { i = 4; }
+	else if (i == 1) { i = 3; }
+	else if (i == 3) { i = 1; }
+	else if (i == 4) { i = 0; }
+	return i;
+}
+
+function difficulty(i) {
+	// To create the magic square we need 2 random orderings of the numbers 0, 1, 2, 3, 4.
+	// The following creates those orderings and calls them Table5 and Table1
+	
+	var Num3 = SEED%1000;	// Table5 will use the ones, tens, and hundreds digits.
+
+	var Rem8 = Num3%8;
+	var Rem4 = Math.floor(Rem8/2);
+	var Rem2 = Rem8%2;
+	var Rem5 = Num3%5;
+	var Rem3 = Num3%3;	// Note that Rem2, Rem3, Rem4, and Rem5 are mathematically independent.
+	var RemT = Math.floor(Num3/120);	// This is between 0 and 8		
+
+	// The idea is to begin with an array containing a single number, 0.
+	// Each number 1 through 4 is added in a random spot in the array's current size.
+	// The result - the numbers 0 to 4 are in the array in a random (and uniform) order.
+	var Table5 = [0];
+	Table5.splice(Rem2, 0, 1);
+	Table5.splice(Rem3, 0, 2);
+	Table5.splice(Rem4, 0, 3);
+	Table5.splice(Rem5, 0, 4);
+
+	Num3 = Math.floor(SEED/1000);	// Table1 will use the next 3 digits.
+	Num3 = Num3%1000;
+
+	Rem8 = Num3%8;
+	Rem4 = Math.floor(Rem8/2);
+	Rem2 = Rem8%2;
+	Rem5 = Num3%5;
+	Rem3 = Num3%3;
+	RemT = RemT * 8 + Math.floor(Num3/120);	 // This is between 0 and 64.
+
+	var Table1 = [0];
+	Table1.splice(Rem2, 0, 1);
+	Table1.splice(Rem3, 0, 2);
+	Table1.splice(Rem4, 0, 3);
+	Table1.splice(Rem5, 0, 4);
+
+	i--;
+	RemT = RemT%5;		//  Between 0 and 4, fairly uniformly.
+	x = (i+RemT)%5;		//  RemT is horizontal shift to put any diagonal on the main diagonal.
+	y = Math.floor(i/5);
+
+	// The Tables are set into a single magic square template
+	// Some are the same up to some rotation, reflection, or row permutation.
+	// However, all genuinely different magic squares can arise in this fashion.
+	var e5 = Table5[(x + 3*y)%5];
+	var e1 = Table1[(3*x + y)%5];
+
+	// Table5 controls the 5* part and Table1 controls the 1* part.
+	value = 5*e5 + e1;
+
+	if (MODE == "short") { value = Math.floor(value/2); } // if short mode, limit difficulty
+    	else if (MODE == "long") { value = Math.floor((value + 25) / 2); }
+    	value++;
+	return value;
+}
+
+//Uniformly shuffles an array (note: the original array will be changed)
+function shuffle(toShuffle)
+{
+	for(var i=0;i<toShuffle.length;i++)
+	{
+		var randElement = Math.floor(Math.random()*(i+1));
+		var temp = toShuffle[i];
+		toShuffle[i] = toShuffle[randElement];
+		toShuffle[randElement] = temp;
+	}
+}
+
+//Get a uniformly shuffled array of all the goals of a given difficulty tier
+function getShuffledGoals(difficulty)
+{
+	var newArray = bingoList[difficulty].slice();
+	shuffle(newArray);
+	return newArray;
+}
+
+//Given a difficulty as an argument, find the square that contains that difficulty
+function getDifficultyIndex(difficulty)
+{
+	for(var i=1;i<=25;i++)
+	{
+		if(bingoBoard[i].difficulty == difficulty)
+		{
+			return i;
+		}
+	}
+	return 0;
+}
+  
+
+
+function checkLine(i, testsquare)
+{
+	var typesA = testsquare.types;
+	var synergy = 0;
+	var rows = rowCheckList[i], elements = [];
+	var childCount = 0;
+	for(var k=0;k<rows.length;k++)
+	{
+		elements = rowElements[rows[k]];
+		childCount = 0;
+		for(var m=0;m<elements.length;m++)
+		{
+			var typesB = bingoBoard[elements[m]].types;
+			if(typeof typesB != 'undefined')
+			{
+				for(var n=0;n<typesA.length;n++)
+				{
+					for(var p=0;p<typesB.length;p++)
+					{
+						if(typesA[n] == typesB[p])
+						{
+							synergy++; //if match increase
+							if(n==0) { synergy++ }; //if main type increase
+							if(p==0) { synergy++ }; //if main type increase
+						}
+					}
+				}
+			}
+			if(bingoBoard[elements[m]].child == "yes")
+			{
+				childCount++;
+			}
+		}
+		//Remove child-only rows, remove adult goals from short
+		if(MODE == "short")
+		{
+			if(testsquare.child == "no")
+			{
+				childCount--;
+			}
+			console.debug(rows[k]);
+			console.debug(childCount);
+			if(childCount < 5)
+			{
+				synergy += 3;
+			}
+		}
+		else
+		{
+			if(testsquare.child == "yes")
+			{
+				childCount++;
+			}
+			if(childCount > 4)
+			{
+				synergy += 3;
+			}
+		}
+	}
+	return synergy;
+}
+
+
+
+  var bingoBoard = []; //the board itself stored as an array first
+  for (var i=1;i<=25;i++) {
+	if(MODE == "short")
+	{
+        bingoBoard[i] = {difficulty: difficulty(i), child: "yes"};
+    }
+    else
+    {
+		bingoBoard[i] = {difficulty: difficulty(i), child: "no"};
+	}
+  }                                          // in order 1-25
+  
+  
+    //giuocob 19-2-13: bingoBoard is no longer populated left to right:
+    //It is now populated mostly randomly, with high difficult goals and
+    //goals on the diagonals out in front
+    var populationOrder = [];
+    populationOrder[1] = 13;   //Populate center first
+    var diagonals = [1,7,19,25,5,9,17,21];
+    shuffle(diagonals);
+    populationOrder = populationOrder.concat(diagonals);   //Next populate diagonals
+    var nondiagonals = [2,3,4,6,8,10,11,12,14,15,16,18,20,22,23,24];
+    shuffle(nondiagonals);
+    populationOrder = populationOrder.concat(nondiagonals);   //Finally add the rest of the squares
+    //Lastly, find location of difficulty 23,24,25 elements and put them out front
+    for(var k=23;k<=25;k++)
+    {
+		var currentSquare = getDifficultyIndex(k);
+		if(currentSquare == 0) continue;
+		for(var i=1;i<25;i++)
+		{
+			if(populationOrder[i] == currentSquare)
+			{
+				populationOrder.splice(i,1);
+				break;
+			}
+		}
+		populationOrder.splice(1,0,currentSquare);
+	}
+
+    
+  
+    //Populate the bingo board in the array
+    //giuocob 16-8-12: changed this section to:
+    //1. Support uniform goal selection by shuffling arrays before checking goals
+    //2. Remove all child rows by checking child tag
+    //3. If no goal is suitable, instead of choosing goal with lowest synergy, now next difficulty up is checked
+    for(var i=1;i<=25;i++)
+    {
+		var sq = populationOrder[i];
+		var getDifficulty = bingoBoard[sq].difficulty;
+		var goalArray = getShuffledGoals(getDifficulty);
+		var j=0, synergy=0, currentObj=null, minSynObj=null;
+		do
+		{
+			currentObj = goalArray[j];
+			synergy = checkLine(sq,currentObj);
+			if(minSynObj == null || synergy < minSynObj.synergy)
+			{
+				minSynObj = {synergy: synergy, value: currentObj};
+			}
+			j++;
+			if(j >= goalArray.length)
+			{
+				getDifficulty++;
+				if(getDifficulty > 25)
+				{
+					break;
+				}
+				else
+				{
+				    goalArray = getShuffledGoals(getDifficulty);
+				    j = 0;
+				}
+			}
+		} while(synergy != 0);   //Perhaps increase to 1 if difficulty increases happen too often
+		
+    
+    bingoBoard[sq].types = minSynObj.value.types;
+    bingoBoard[sq].name = minSynObj.value[LANG] || minSynObj.value.name;
+    bingoBoard[sq].child = minSynObj.value.child;
+    bingoBoard[sq].synergy = minSynObj.synergy;
+  }
+
+  return bingoBoard;
+}

--- a/versions/v8/v8.0/goal-list.js
+++ b/versions/v8/v8.0/goal-list.js
@@ -1,0 +1,215 @@
+var bingoList = [];
+bingoList["info"] = {
+  version: "v8.0"
+};
+bingoList[1] = [
+  { name: "Bottled Fairy", jp: 'ビン(妖精)', types: ["bottle"], child: "yes" },
+  { name: "Bullet Bag (50)", jp: 'デクのタネ袋(50)', types: ["bulletbag"], child: "yes" },
+  { name: "Lens of Truth", jp: 'まことのメガネ', types: ["botw"], child: "yes" },
+  { name: "Defeat a Skull Kid", jp: 'スタルキッド撃破', types: ["skullkid", "forest"], child: "no" },
+  { name: "Map & Compass in Dodongo's Cavern", jp: 'ドドンゴの洞窟のマップとコンパス', types: ["dc", "dungeon_item"], child: "yes" },
+  { name: "Adult's Wallet", jp: '大人のサイフ', types: ["wallet", "atrade"], child: "yes" },
+  { name: "At least 30 Deku Nuts", jp: 'デクの実30個以上', types: ["nuts", "forest"], child: "yes" }
+];
+bingoList[2] = [
+  { name: "Map & Compass in Bottom of the Well", jp: '井戸の底のマップとコンパス', types: ["botw", "dungeon_item"], child: "yes" },
+  { name: "Fairy Slingshot", jp: '妖精のパチンコ', types: ["bulletbag", "deku"], child: "yes" },
+  { name: "Giant's Knife", jp: '巨人のナイフ', types: ["sets", "wallet", "dmc"], child: "no" },
+  { name: "Bomb Bag (30)", jp: 'ボム袋(30)', types: ["bombbag", "dc", "atrade"], child: "yes" },
+  { name: "Minuet of Forest", jp: '森のメヌエット', types: ["forest", "songs"], child: "no" },
+  { name: "Zora Tunic", jp: 'ゾーラの服', types: ["sets", "ice"], child: "no" }
+];
+bingoList[3] = [
+  { name: "Map & Compass in Deku Tree", jp: 'デクの樹様の中のマップとコンパス', types: ["deku", "dungeon_item"], child: "yes" },
+  { name: "Goron Tunic", jp: 'ゴロンの服', types: ["sets", "dmc", "fire"], child: "no" },
+  { name: "Defeat King Dodongo", jp: 'キングドドンゴ撃破', types: ["dc"], child: "yes" },
+  { name: "At least 3 songs", jp: '歌3つ以上', types: ["songs", "zl"], child: "yes" },
+  { name: "Quiver (40)", jp: '矢立て(40)', types: ["atrade", "forest", "quiver"], child: "no" },
+  { name: "Defeat all Lizalfos in Dodongo's Cavern", jp: 'ドドンゴの洞窟のリザルフォス全て撃破', types: ["dc"], child: "yes" },
+  { name: "Ruto's Letter", jp: 'ルトの手紙', types: ["bottle", "ruto"], child: "yes" }
+];
+bingoList[4] = [
+  { name: "Bullet Bag (40)", jp: 'デクのタネ袋(40)', types: ["bulletbag", "deku"], child: "yes" },
+  { name: "Both heart pieces in Death Mountain Crater", jp: 'デスマウンテン火口のハートのかけら２つ', types: ["dmc", "fire", "hearts"], child: "yes" },
+  { name: "Ice Arrows", jp: '氷の矢', types: ["fortress", "quiver", "water"], child: "yes" },
+  { name: "Map & Compass in Shadow Temple", jp: '闇の神殿のマップとコンパス', types: ["shadow", "dungeon_item"], child: "yes" },
+  { name: "Beat Dodongo's Cavern", jp: 'ドドンゴの洞窟クリア', types: ["dc", "fortress"], child: "yes" },
+  { name: "Bolero of Fire", jp: '炎のボレロ', types: ["dmc", "fire", "songs"], child: "no" }
+];
+bingoList[5] = [
+  { name: "Defeat Queen Gohma", jp: 'ゴーマ撃破', types: ["deku", "ganon"], child: "yes" },
+  { name: "Milk", jp: 'ロンロン牛乳', types: ["lonlon", "zl", "bottle"], child: "yes" },
+  { name: "Blue Fire", jp: '青い炎', types: ["ice", "bottle", "deku", "ganon"], child: "yes" },
+  { name: "Defeat a White Wolfos", jp: 'ホワイトウルフォス撃破', types: ["ice", "fortress", "ganon"], child: "yes" },
+  { name: "All 3 Kokiri Forest area Skulltulas", jp: 'コキリの森エリアの黄金のスタルチュラ３匹', types: ["deku", "forest"], child: "no" },
+  { name: "30 Deku Sticks", jp: 'デクの棒30本', types: ["atrade", "ctrade"], child: "yes" }
+];
+bingoList[6] = [
+  { name: "Cow in House", jp: '牛(リンクの家)', types: ["cow", "hearts"], child: "no" },
+  { name: "Fire Temple Boss Key", jp: '炎の神殿のボス部屋のカギ', types: ["fire", "dungeon_item"], child: "no" },
+  { name: "Beat the Deku Tree", jp: 'デクの樹様の中クリア', types: ["deku", "ganon"], child: "yes" },
+  { name: "3 Tunics", jp: '服3種類', types: ["sets", "ice"], child: "no" },
+  { name: "3 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ3つ', types: ["fortress"], child: "yes" },
+  { name: "Epona's Song", jp: 'エポナの歌', types: ["lonlon", "songs"], child: "yes" }
+];
+bingoList[7] = [
+  { name: "6 Hearts", jp: 'ハート6つ', types: ["hearts", "barinade", "pganon", "volvagia", "morpha", "bongo", "twinrova"], child: "yes" },
+  { name: "4 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ4つ', types: ["fortress"], child: "yes" },
+  { name: "Plant bean in Death Mountain Crater", jp: 'デスマウンテン火口の土にマメを植える', types: ["dmc", "beans"], child: "yes" },
+  { name: "Ice Cavern Heart Piece", jp: '氷の洞窟のハートのかけら', types: ["ice", "hearts"], child: "yes" },
+  { name: "Water Temple Boss Key", jp: '水の神殿のボス部屋のカギ', types: ["water", "fortress", "dungeon_item"], child: "no" },
+  { name: "Both Gerudo's Fortress area Skulltulas", jp: 'ゲルドの砦の黄金のスタルチュラ2匹', types: ["fortress"], child: "no" },
+  { name: "All 4 Lost Woods area Skulltulas", jp: '迷いの森エリアの黄金のスタルチュラ4匹', types: ["forest"], child: "no" },
+  { name: "Fill all 4 Bottle Slots", jp: '4つの空きビンスロットを全て埋める', types: ["bottle"], child: "yes" }
+];
+bingoList[8] = [
+  { name: "Defeat Phantom Ganon", jp: 'ファントムガノン撃破', types: ["forest", "pganon"], child: "yes" },
+  { name: "Map & Compass in Ice Cavern", jp: '氷の洞窟のマップとコンパス', types: ["ice", "dungeon_item"], child: "no" },
+  { name: "All 3 Skulltulas in Ice Cavern", jp: '氷の洞窟の黄金のスタルチュラ3匹', types: ["ice"], child: "yes" },
+  { name: "At least 4 songs", jp: '歌4つ以上', types: ["songs", "atrade", "zl"], child: "yes" },
+  { name: "All 5 Skulltulas in Dodongo's Cavern", jp: 'ドドンゴの洞窟の黄金のスタルチュラ5匹', types: ["dc"], child: "yes" },
+  { name: "Ganon's Castle Boss Key", jp: 'ガノン城のボス部屋のカギ', types: ["ganon", "deku", "dungeon_item"], child: "yes" },
+  { name: "Giant's Wallet", jp: '巨人のサイフ', types: ["wallet", "atrade"], child: "yes" },
+  { name: "37th heart piece (Child Fortress)", jp: '37番目のハートのかけら(子供のゲルドの砦)', types: ["fortress", "hearts"], child: "yes" }
+];
+bingoList[9] = [
+  { name: "At least 7 Magic Beans", jp: '魔法のマメ7つ以上', types: ["beans", "ctrade"], child: "yes" },
+  { name: "Beat the Forest Temple", jp: '森の神殿クリア', types: ["forest", "pganon"], child: "yes" },
+  { name: "Defeat Big Octo", jp: '大オクタ撃破', types: ["jabu"], child: "yes" },
+  { name: "Iron Boots", jp: 'ヘビーブーツ', types: ["ice", "sets"], child: "yes" },
+  { name: "3 Swords & 3 Tunics", jp: '剣3種類と服3種類', types: ["sets", "ice", "wallet"], child: "no" },
+  { name: "All 3 Skulltulas in Bottom of the Well", jp: '井戸の底の黄金のスタルチュラ3匹', types: ["botw"], child: "yes" },
+  { name: "6 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ6つ', types: ["fortress"], child: "yes" }
+];
+bingoList[10] = [
+  { name: "Requiem of Spirit", jp: '魂のレクイエム', types: ["spirit", "songs"], child: "yes" },
+  { name: "3 Boots", jp: '靴3種類', types: ["sets", "ice"], child: "yes" },
+  { name: "Blue Potion", jp: '青いクスリ', types: ["atrade", "zl"], child: "no" },
+  { name: "All 4 Skulltulas in Deku Tree", jp: 'デクの樹様の中の黄金のスタルチュラ4匹', types: ["deku"], child: "yes" },
+  { name: "All 8 Kakariko area Skulltulas", jp: 'カカリコ村エリアの黄金のスタルチュラ8匹', types: ["botw"], child: "no" },
+  { name: "Map & Compass in Jabu-Jabu", jp: 'ジャブジャブ様のお腹のマップとコンパス', types: ["jabu", "dungeon_item"], child: "yes" },
+  { name: "Forest Medallion", jp: '森のメダル', types: ["forest", "lightarrow", "atrade", "pganon"], child: "yes" },
+  { name: "Defeat Morpha", jp: 'モーファ撃破', types: ["water", "morpha"], child: "no" }
+];
+bingoList[11] = [
+  { name: "At least 6 songs", jp: '歌6つ以上', types: ["songs", "atrade", "zl"], child: "no" },
+  { name: "7 Hearts", jp: 'ハート7つ', types: ["hearts", "barinade", "pganon", "volvagia", "morpha", "bongo", "twinrova"], child: "yes" },
+  { name: "All 5 Skulltulas in Forest Temple", jp: '森の神殿の黄金のスタルチュラ5匹', types: ["forest"], child: "no" },
+  { name: "Beat the Water Temple", jp: '水の神殿クリア', types: ["water", "morpha"], child: "no" },
+  { name: "Golden Gauntlets", jp: '金のグローブ', types: ["strength", "ganon", "deku"], child: "yes" },
+  { name: "Get Bombchu chest in Spirit Temple", jp: '魂の神殿のボムチュウ取得', types: ["spirit", "strength"], child: "yes" },
+  { name: "Stone of Agony", jp: 'もだえ石', types: ["wallet"], child: "yes" }
+];
+bingoList[12] = [
+  { name: "All 4 Skulltulas in Jabu-Jabu", jp: 'ジャブジャブ様のお腹の黄金のスタルチュラ4匹', types: ["jabu", "barinade"], child: "yes" },
+  { name: "Water Medallion", jp: '水のメダル', types: ["water", "lightarrow", "atrade", "morpha"], child: "no" },
+  { name: "Gerudo's Card", jp: 'ゲルドの会員証', types: ["fortress"], child: "yes" },
+  { name: "Fairy Bow", jp: '妖精の弓', types: ["forest", "quiver"], child: "no" },
+  { name: "Defeat Dark Link", jp: 'ダークリンク撃破', types: ["water", "ice"], child: "no" },
+  { name: "Silver Gauntlets", jp: '銀のグローブ', types: ["strength", "spirit"], child: "yes" },
+  { name: "Bottled Big Poe", jp: 'ビン(ビッグポウ)', types: ["quiver", "forest", "fortress"], child: "no" },
+  { name: "500 Rupees", jp: '500ルピー', types: ["wallet", "atrade"], child: "yes" }
+];
+bingoList[13] = [
+  { name: "Double Magic", jp: '魔力2倍', types: ["dmc", "zl"], child: "yes" },
+  { name: "Defeat Barinade", jp: 'バリネード撃破', types: ["jabu", "barinade"], child: "yes" },
+  { name: "All 4 Gerudo Valley area Skulltulas", jp: 'ゲルドの谷エリアの黄金のスタルチュラ4匹', types: ["fortress", "jabu"], child: "no" },
+  { name: "Longshot", jp: 'ロングフック', types: ["water", "ice"], child: "no" },
+  { name: "3 Tunics & 3 Boots", jp: '服3種類と靴3種類', types: ["sets", "ice"], child: "no" },
+  { name: "Mirror Shield", jp: 'ミラーシールド', types: ["sets", "spirit", "mirror"], child: "yes" },
+  { name: "Keaton Mask", jp: 'キータンのお面', types: ["masks", "zl"], child: "yes" },
+  { name: "Map & Compass in Forest Temple", jp: '森の神殿のマップとコンパス', types: ["forest", "quiver", "dungeon_item"], child: "no" }
+];
+bingoList[14] = [
+  { name: "Double Defense", jp: '防御力2倍', types: ["zl", "ganon"], child: "no" },
+  { name: "Map & Compass in Fire Temple", jp: '炎の神殿のマップとコンパス', types: ["fire", "dungeon_item"], child: "no" },
+  { name: "Bombchu Bowling Heart Piece", jp: 'ボムチュウボウリングのハートのかけら', types: ["dc", "hearts"], child: "yes" },
+  { name: "Forest Temple Boss Key", jp: '森の神殿のボス部屋のカギ', types: ["forest", "dungeon_item", "claimcheck", "quiver"], child: "no" },
+  { name: "Defeat Amy (Green Poe)", jp: 'エイミー撃破(緑のポウ)ｴ', types: ["forest", "fortress", "quiver"], child: "no" },
+  { name: "All 4 Lon-Lon Ranch area Skulltulas", jp: 'ロンロン牧場エリアの黄金のスタルチュラ4匹', types: ["jabu", "lonlon"], child: "yes" }
+];
+bingoList[15] = [
+  { name: "Map & Compass in Water Temple", jp: '水の神殿のマップとコンパス', types: ["water", "ice", "dungeon_item"], child: "no" },
+  { name: "At least 9 Magic Beans", jp: '魔法のマメ9つ以上', types: ["beans", "ctrade"], child: "yes" },
+  { name: "Farore's Wind", jp: 'フロルの風', types: ["zl", "ice"], child: "yes" },
+  { name: "Megaton Hammer", jp: 'メガトンハンマー', types: ["fire"], child: "no" },
+  { name: "Get to the end of Fire Trial", jp: '炎の結界の最後の部屋に到達', types: ["ganon", "strength", "fire"], child: "no" },
+  { name: "6 Maps", jp: 'マップ6つ', types: ["dungeon_item", "claimcheck", "ice"], child: "yes" },
+  { name: "Beat Jabu-Jabu's Belly", jp: 'ジャブジャブ様のお腹クリア', types: ["jabu", "barinade"], child: "yes" },
+  { name: "All 8 Death Mountain area Skulltulas", jp: 'デスマウンテンエリアの黄金のスタルチュラ8匹', types: ["fire", "dmc"], child: "no" }
+];
+bingoList[16] = [
+  { name: "Defeat both Flare Dancers", jp: 'フレアダンサー2体撃破', types: ["fire"], child: "no" },
+  { name: "Bronze Gauntlets", jp: '銅のグローブ', types: ["strength", "bulletbag", "ganon", "atrade"], child: "no" },
+  { name: "3 Swords & 3 Boots", jp: '剣3種類と靴3種類', types: ["sets", "ice"], child: "no" },
+  { name: "At least 3 Skulltulas in Water Temple", jp: '水の神殿の黄金のスタルチュラ3匹以上', types: ["water", "ice"], child: "no" },
+  { name: "3 Boss Keys", jp: 'ボス部屋のカギ3つ', types: ["dungeon_item", "claimcheck"], child: "no" },
+  { name: "At least 8 songs", jp: '歌8つ以上', types: ["songs", "atrade", "zl"], child: "no" },
+  { name: "Saria's Song", jp: 'サリアの歌', types: ["strength", "masks", "songs", "zl", "saria"], child: "yes" },
+  { name: "8 Hearts", jp: 'ハート8つ', types: ["hearts", "barinade", "pganon", "volvagia", "morpha", "bongo", "twinrova"], child: "yes" }
+];
+bingoList[17] = [
+  { name: "Shadow Temple Boss Key", jp: '闇の神殿のボス部屋のカギ', types: ["shadow", "zl", "dungeon_item"], child: "no" },
+  { name: "All 5 Skulltulas in Fire Temple", jp: '炎の神殿の黄金のスタルチュラ5匹', types: ["fire", "songs"], child: "no" },
+  { name: "All 8 Zora's Domain area Skulltulas", jp: 'ゾーラの里エリアの黄金のスタルチュラ8匹', types: ["jabu", "strength", "ice"], child: "no" },
+  { name: "Blue Gauntlets", jp: '青のグローブ', types: ["spirit", "strength", "bulletbag", "atrade"], child: "no" },
+  { name: "Defeat Nabooru-Knuckle", jp: 'アイアンナック(ナボール)撃破', types: ["spirit"], child: "no" },
+  { name: "Both Hyrule Field area Skulltulas", jp: 'ハイラル平原エリアの黄金のスタルチュラ2匹', types: ["zl", "water"], child: "yes" },
+  { name: "3 Swords & 3 Shields", jp: '剣3種類と盾3種類', types: ["sets", "spirit"], child: "no" }
+];
+bingoList[18] = [
+  { name: "Defeat Volvagia", jp: 'ヴァルバジア撃破', types: ["fire", "sets", "volvagia"], child: "no" },
+  { name: "Din's Fire", jp: 'ディンの炎', types: ["zl"], child: "yes" },
+  { name: "Frog's Heart Piece", jp: 'カエルのハートのかけら(嵐の歌)', types: ["songs", "forest", "hearts"], child: "no" },
+  { name: "All 4 Wasteland/ Colossus area Skulltulas", jp: '幻影の砂漠・巨大邪神像エリアの黄金のスタルチュラ4匹', types: ["spirit"], child: "no" },
+  { name: "Fire Arrow", jp: '炎の矢', types: ["water", "firearrow", "quiver"] },
+  { name: "Defeat Bongo-Bongo", jp: 'ボンゴボンゴ撃破', types: ["shadow", "zl", "deku", "bongo"], child: "no" }
+];
+bingoList[19] = [
+  { name: "Get to the end of Light Trial", jp: '光の結界の最後の部屋に到達', types: ["ganon", "zl", "strength"], child: "no" },
+  { name: "3 Shields & 3 Tunics", jp: '盾3種類と服3種類', types: ["sets", "spirit"], child: "no" },
+  { name: "6 Compasses", jp: 'コンパス6つ', types: ["dungeon_item", "ice"], child: "yes" },
+  { name: "Beat the Fire Temple", jp: '炎の神殿クリア', types: ["fire", "forest", "volvagia"], child: "no" },
+  { name: "Goron Bracelet", jp: 'ゴロンの腕輪', types: ["strength", "zl", "saria"], child: "yes" },
+  { name: "All 5 Skulltulas in Spirit Temple", jp: '魂の神殿の黄金のスタルチュラ5匹', types: ["spirit", "atrade", "songs"], child: "yes" }
+];
+bingoList[20] = [
+  { name: "Free all 9 gorons in Fire Temple", jp: '炎の神殿で９人のゴロンを全員救う', types: ["fire", "sets", "ganon"], child: "no" },
+  { name: "Nayru's Love", jp: 'ネールの愛', types: ["spirit", "zl"], child: "yes" },
+  { name: "Both heart pieces in Lost Woods", jp: '迷いの森のハートのかけら２つ', types: ["strength", "masks", "songs", "zl", "hearts"], child: "yes" },
+  { name: "All 5 Lake Hylia Skulltulas", jp: 'ハイリア湖畔エリアの黄金のスタルチュラ5匹', types: ["ice", "water"], child: "no" },
+  { name: "Beat the Shadow Temple", jp: '闇の神殿クリア', types: ["shadow", "zl", "deku", "bongo"], child: "no" }
+];
+bingoList[21] = [
+  { name: "Spooky Mask", jp: 'こわそなお面', types: ["masks", "strength", "zl", "fortress", "saria", "beans"], child: "yes" },
+  { name: "Defeat Meg (purple Poe)", jp: 'メグ撃破(紫のポウ)', types: ["forest", "quiver"], child: "no" },
+  { name: "7 Maps", jp: 'マップ7つ', types: ["dungeon_item", "claimcheck", "ice"], child: "yes" },
+  { name: "Light Arrows", jp: '光の矢', types: ["lightarrow", "atrade"], child: "no" },
+  { name: "At least 9 songs", jp: '歌9つ以上', types: ["songs", "atrade", "zl"], child: "no" },
+  { name: "8 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ8つ', types: ["fortress", "water"], child: "no" }
+];
+bingoList[22] = [
+  { name: "3 Shields & 3 Boots", jp: '盾3種類と靴3種類', types: ["sets", "spirit", "ice"], child: "yes" },
+  { name: "9 Hearts", jp: 'ハート9つ', types: ["hearts", "saria", "barinade", "pganon", "volvagia", "morpha", "bongo", "twinrova"], child: "yes" },
+  { name: "Get to the end of Water Trial", jp: '水の結界の最後の部屋に到達', types: ["ganon", "fire", "lightarrow"], child: "no" },
+  { name: "All 4 Market area Skulltulas", jp: '城下町エリアの黄金のスタルチュラ4匹', types: ["forest", "pganon"], child: "no" },
+  { name: "Map & Compass in Spirit Temple", jp: '魂の神殿のマップとコンパス', types: ["spirit", "zl", "dungeon_item"], child: "yes" }
+];
+bingoList[23] = [
+  { name: "Quiver (50)", jp: '矢立て(50)', types: ["quiver", "fortress"], child: "no" },
+  { name: "Two Fairy Spells", jp: '魔法のアイテム２つ', types: ["zl", "ice", "spirit"], child: "yes" },
+  { name: "Spirit Temple Boss Key", jp: '魂の神殿のボス部屋のカギ', types: ["spirit", "lightarrow", "zl", "dungeon_item"], child: "no" },
+  { name: "7 Compasses", jp: 'コンパス7つ', types: ["dungeon_item", "ice"], child: "no" }
+];
+bingoList[24] = [
+  { name: "Defeat Twinrova", jp: 'ツインローバ撃破', types: ["spirit", "twinrova"], child: "no" },
+  { name: "Green Gauntlets", jp: '緑のグローブ', types: ["strength", "bulletbag", "zl", "atrade", "saria"], child: "no" },
+  { name: "All 5 Skulltulas in Shadow Temple", jp: '闇の神殿の黄金のスタルチュラ5匹', types: ["shadow", "zl"], child: "no" },
+  { name: "Get to the end of Spirit Trial", jp: '魂の結界の最後の部屋に到達', types: ["ganon", "spirit", "quiver"], child: "no" }
+];
+bingoList[25] = [
+  { name: "Beat the Spirit Temple", jp: '魂の神殿クリア', types: ["spirit", "twinrova"], child: "no" },
+  { name: "Get to the end of the Forest Trial", jp: '森の結界の最後の部屋に到達', types: ["ganon", "zl", "firearrow"], child: "yes" },
+  { name: "All 5 Skulltulas in Water Temple", jp: '水の神殿の黄金のスタルチュラ5匹', types: ["water"], child: "no" },
+  { name: "Get to the end of Shadow Trial", jp: '闇の結界の最後の部屋に到達', types: ["ganon", "fire"], child: "no" }
+];

--- a/versions/v8/v8.1/generator.js
+++ b/versions/v8/v8.1/generator.js
@@ -1,0 +1,261 @@
+//NOTICE: As of version 6, this script will only generate cards correctly for Ocarina of Time bingo
+//and as shuch should be saved alongside the regular bingo script.
+ootBingoGenerator = function (bingoList, opts) {
+	if (!opts) opts = {};
+	var LANG = opts.lang || 'name';
+	var SEED = opts.seed || Math.ceil(999999 * Math.random()).toString();
+	Math.seedrandom(SEED);
+	var MODE = opts.mode || 'normal';
+
+	//giuocob 16-8-12: lineCheckList[] has been replaced to allow for removal of all-child rows
+	//Note: the rowElements relation is simply the inverse of the rowCheckList relation
+	var rowElements = {};
+	rowElements["row1"] = [1, 2, 3, 4, 5];
+	rowElements["row2"] = [6, 7, 8, 9, 10];
+	rowElements["row3"] = [11, 12, 13, 14, 15];
+	rowElements["row4"] = [16, 17, 18, 19, 20];
+	rowElements["row5"] = [21, 22, 23, 24, 25];
+	rowElements["col1"] = [1, 6, 11, 16, 21];
+	rowElements["col2"] = [2, 7, 12, 17, 22];
+	rowElements["col3"] = [3, 8, 13, 18, 23];
+	rowElements["col4"] = [4, 9, 14, 19, 24];
+	rowElements["col5"] = [5, 10, 15, 20, 25];
+	rowElements["tlbr"] = [1, 7, 13, 19, 25];
+	rowElements["bltr"] = [5, 9, 13, 17, 21];
+
+	//Given an object that maps keys to flat arrays, invert said object
+	function invertObject(obj) {
+		var ret = {};
+		Object.keys(obj).forEach(function (key) {
+			obj[key].forEach(function (item) {
+				if (!ret[item]) ret[item] = [];
+				ret[item].push(key);
+			});
+		});
+		return ret;
+	}
+
+	rowCheckList = invertObject(rowElements);
+
+	function mirror(i) {
+		if (i == 0) { i = 4; }
+		else if (i == 1) { i = 3; }
+		else if (i == 3) { i = 1; }
+		else if (i == 4) { i = 0; }
+		return i;
+	}
+
+	function difficulty(i) {
+		// To create the magic square we need 2 random orderings of the numbers 0, 1, 2, 3, 4.
+		// The following creates those orderings and calls them Table5 and Table1
+
+		var Num3 = SEED % 1000;	// Table5 will use the ones, tens, and hundreds digits.
+
+		var Rem8 = Num3 % 8;
+		var Rem4 = Math.floor(Rem8 / 2);
+		var Rem2 = Rem8 % 2;
+		var Rem5 = Num3 % 5;
+		var Rem3 = Num3 % 3;	// Note that Rem2, Rem3, Rem4, and Rem5 are mathematically independent.
+		var RemT = Math.floor(Num3 / 120);	// This is between 0 and 8		
+
+		// The idea is to begin with an array containing a single number, 0.
+		// Each number 1 through 4 is added in a random spot in the array's current size.
+		// The result - the numbers 0 to 4 are in the array in a random (and uniform) order.
+		var Table5 = [0];
+		Table5.splice(Rem2, 0, 1);
+		Table5.splice(Rem3, 0, 2);
+		Table5.splice(Rem4, 0, 3);
+		Table5.splice(Rem5, 0, 4);
+
+		Num3 = Math.floor(SEED / 1000);	// Table1 will use the next 3 digits.
+		Num3 = Num3 % 1000;
+
+		Rem8 = Num3 % 8;
+		Rem4 = Math.floor(Rem8 / 2);
+		Rem2 = Rem8 % 2;
+		Rem5 = Num3 % 5;
+		Rem3 = Num3 % 3;
+		RemT = RemT * 8 + Math.floor(Num3 / 120);	 // This is between 0 and 64.
+
+		var Table1 = [0];
+		Table1.splice(Rem2, 0, 1);
+		Table1.splice(Rem3, 0, 2);
+		Table1.splice(Rem4, 0, 3);
+		Table1.splice(Rem5, 0, 4);
+
+		i--;
+		RemT = RemT % 5;		//  Between 0 and 4, fairly uniformly.
+		x = (i + RemT) % 5;		//  RemT is horizontal shift to put any diagonal on the main diagonal.
+		y = Math.floor(i / 5);
+
+		// The Tables are set into a single magic square template
+		// Some are the same up to some rotation, reflection, or row permutation.
+		// However, all genuinely different magic squares can arise in this fashion.
+		var e5 = Table5[(x + 3 * y) % 5];
+		var e1 = Table1[(3 * x + y) % 5];
+
+		// Table5 controls the 5* part and Table1 controls the 1* part.
+		value = 5 * e5 + e1;
+
+		if (MODE == "short") { value = Math.floor(value / 2); } // if short mode, limit difficulty
+		else if (MODE == "long") { value = Math.floor((value + 25) / 2); }
+		value++;
+		return value;
+	}
+
+	//Uniformly shuffles an array (note: the original array will be changed)
+	function shuffle(toShuffle) {
+		for (var i = 0; i < toShuffle.length; i++) {
+			var randElement = Math.floor(Math.random() * (i + 1));
+			var temp = toShuffle[i];
+			toShuffle[i] = toShuffle[randElement];
+			toShuffle[randElement] = temp;
+		}
+	}
+
+	//Get a uniformly shuffled array of all the goals of a given difficulty tier
+	function getShuffledGoals(difficulty) {
+		var newArray = bingoList[difficulty].slice();
+		shuffle(newArray);
+		return newArray;
+	}
+
+	//Given a difficulty as an argument, find the square that contains that difficulty
+	function getDifficultyIndex(difficulty) {
+		for (var i = 1; i <= 25; i++) {
+			if (bingoBoard[i].difficulty == difficulty) {
+				return i;
+			}
+		}
+		return 0;
+	}
+
+
+
+	function checkLine(i, testsquare) {
+		var typesA = testsquare.types;
+		var synergy = 0;
+		var rows = rowCheckList[i], elements = [];
+		var childCount = 0;
+		for (var k = 0; k < rows.length; k++) {
+			elements = rowElements[rows[k]];
+			childCount = 0;
+			for (var m = 0; m < elements.length; m++) {
+				var typesB = bingoBoard[elements[m]].types;
+				if (typeof typesB != 'undefined') {
+					for (var n = 0; n < typesA.length; n++) {
+						for (var p = 0; p < typesB.length; p++) {
+							if (typesA[n] == typesB[p]) {
+								synergy++; //if match increase
+								if (n == 0) { synergy++ }; //if main type increase
+								if (p == 0) { synergy++ }; //if main type increase
+							}
+						}
+					}
+				}
+				if (bingoBoard[elements[m]].child == "yes") {
+					childCount++;
+				}
+			}
+			//Remove child-only rows, remove adult goals from short
+			if (MODE == "short") {
+				if (testsquare.child == "no") {
+					childCount--;
+				}
+				console.debug(rows[k]);
+				console.debug(childCount);
+				if (childCount < 5) {
+					synergy += 3;
+				}
+			}
+			else {
+				if (testsquare.child == "yes") {
+					childCount++;
+				}
+				if (childCount > 4) {
+					synergy += 3;
+				}
+			}
+		}
+		return synergy;
+	}
+
+
+
+	var bingoBoard = []; //the board itself stored as an array first
+	for (var i = 1; i <= 25; i++) {
+		if (MODE == "short") {
+			bingoBoard[i] = { difficulty: difficulty(i), child: "yes" };
+		}
+		else {
+			bingoBoard[i] = { difficulty: difficulty(i), child: "no" };
+		}
+	}                                          // in order 1-25
+
+
+	//giuocob 19-2-13: bingoBoard is no longer populated left to right:
+	//It is now populated mostly randomly, with high difficult goals and
+	//goals on the diagonals out in front
+	var populationOrder = [];
+	populationOrder[1] = 13;   //Populate center first
+	var diagonals = [1, 7, 19, 25, 5, 9, 17, 21];
+	shuffle(diagonals);
+	populationOrder = populationOrder.concat(diagonals);   //Next populate diagonals
+	var nondiagonals = [2, 3, 4, 6, 8, 10, 11, 12, 14, 15, 16, 18, 20, 22, 23, 24];
+	shuffle(nondiagonals);
+	populationOrder = populationOrder.concat(nondiagonals);   //Finally add the rest of the squares
+	//Lastly, find location of difficulty 23,24,25 elements and put them out front
+	for (var k = 23; k <= 25; k++) {
+		var currentSquare = getDifficultyIndex(k);
+		if (currentSquare == 0) continue;
+		for (var i = 1; i < 25; i++) {
+			if (populationOrder[i] == currentSquare) {
+				populationOrder.splice(i, 1);
+				break;
+			}
+		}
+		populationOrder.splice(1, 0, currentSquare);
+	}
+
+
+
+	//Populate the bingo board in the array
+	//giuocob 16-8-12: changed this section to:
+	//1. Support uniform goal selection by shuffling arrays before checking goals
+	//2. Remove all child rows by checking child tag
+	//3. If no goal is suitable, instead of choosing goal with lowest synergy, now next difficulty up is checked
+	for (var i = 1; i <= 25; i++) {
+		var sq = populationOrder[i];
+		var getDifficulty = bingoBoard[sq].difficulty;
+		var goalArray = getShuffledGoals(getDifficulty);
+		var j = 0, synergy = 0, currentObj = null, minSynObj = null;
+		do {
+			currentObj = goalArray[j];
+			synergy = checkLine(sq, currentObj);
+			if (minSynObj == null || synergy < minSynObj.synergy) {
+				minSynObj = { synergy: synergy, value: currentObj };
+			}
+			j++;
+			if (j >= goalArray.length) {
+				getDifficulty++;
+				if (getDifficulty > 25) {
+					break;
+				}
+				else {
+					goalArray = getShuffledGoals(getDifficulty);
+					j = 0;
+				}
+			}
+		} while (synergy != 0);   //Perhaps increase to 1 if difficulty increases happen too often
+
+
+		bingoBoard[sq].types = minSynObj.value.types;
+		bingoBoard[sq].name = minSynObj.value[LANG] || minSynObj.value.name;
+		bingoBoard[sq].child = minSynObj.value.child;
+		bingoBoard[sq].synergy = minSynObj.synergy;
+
+	}
+
+	return bingoBoard;
+
+}

--- a/versions/v8/v8.1/goal-list.js
+++ b/versions/v8/v8.1/goal-list.js
@@ -1,0 +1,213 @@
+var bingoList = [];
+bingoList["info"] = {
+  version: "v8.1"
+};
+bingoList[1] = [
+  { name: "Bottled Fairy", jp: 'ビン(妖精)', types: ["bottle"], child: "yes" },
+  { name: "Bullet Bag (50)", jp: 'デクのタネ袋(50)', types: ["bulletbag"], child: "yes" },
+  { name: "Lens of Truth", jp: 'まことのメガネ', types: ["botw"], child: "yes" },
+  { name: "Defeat a Skull Kid", jp: 'スタルキッド撃破', types: ["skullkid"], child: "no" },
+  { name: "Map & Compass in Dodongo's Cavern", jp: 'ドドンゴの洞窟のマップとコンパス', types: ["dc"], child: "yes" },
+  { name: "Adult's Wallet", jp: '大人のサイフ', types: ["wallet"], child: "yes" },
+  { name: "At least 30 Deku Nuts", jp: 'デクの実30個以上', types: ["nuts"], child: "yes" }
+];
+bingoList[2] = [
+  { name: "Map & Compass in Deku Tree", jp: 'デクの樹様の中のマップとコンパス', types: ["deku", "mapcompass"], child: "yes" },
+  { name: "Map & Compass in Bottom of the Well", jp: '井戸の底のマップとコンパス', types: ["botw"], child: "yes" },
+  { name: "Giant's Knife", jp: '巨人のナイフ', types: ["swords", "wallet"], child: "no" },
+  { name: "Bomb Bag (30)", jp: 'ボム袋(30)', types: ["bombbag"], child: "yes" },
+  { name: "Minuet of Forest", jp: '森のメヌエット', types: ["forest", "songs"], child: "no" },
+  { name: "Zora Tunic", jp: 'ゾーラの服', types: ["tunics", "ice"], child: "no" }
+];
+bingoList[3] = [
+  { name: "Fairy Slingshot", jp: '妖精のパチンコ', types: ["bulletbag", "deku"], child: "yes" },
+  { name: "Goron Tunic", jp: 'ゴロンの服', types: ["tunics", "dmc", "fire"], child: "no" },
+  { name: "Defeat King Dodongo", jp: 'キングドドンゴ撃破', types: ["dc"], child: "yes" },
+  { name: "At least 3 songs", jp: '歌3つ以上', types: ["songs", "zl"], child: "yes" },
+  { name: "Quiver (40)", jp: '矢立て(40)', types: ["atrade", "forest", "quiver"], child: "no" },
+  { name: "Defeat all Lizalfos in Dodongo's Cavern", jp: 'ドドンゴの洞窟のリザルフォス全て撃破', types: ["dc"], child: "yes" }
+];
+bingoList[4] = [
+  { name: "Blue Fire", jp: '青い炎', types: ["ice", "bottle", "ganon"], child: "yes" },
+  { name: "Ruto's Letter", jp: 'ルトの手紙', types: ["bottle"], child: "yes" },
+  { name: "Bullet Bag (40)", jp: 'デクのタネ袋(40)', types: ["bulletbag", "deku"], child: "yes" },
+  { name: "Both heart pieces in Death Mountain Crater", jp: 'デスマウンテン火口のハートのかけら２つ', types: ["dmc", "fire", "hearts"], child: "yes" },
+  { name: "Ice Arrows", jp: '氷の矢', types: ["fortress", "quiver"], child: "yes" },
+  { name: "Map & Compass in Shadow Temple", jp: '闇の神殿のマップとコンパス', types: ["shadow", "mapcompass"], child: "yes" },
+  { name: "Bolero of Fire", jp: '炎のボレロ', types: ["dmc", "fire", "songs"], child: "no" }
+];
+bingoList[5] = [
+  { name: "Beat Dodongo's Cavern", jp: 'ドドンゴの洞窟クリア', types: ["dc", "fortress"], child: "yes" },
+  { name: "Fire Temple Boss Key", jp: '炎の神殿のボス部屋のカギ', types: ["fire", "bosskey"], child: "no" },
+  { name: "Ganon's Castle Boss Key", jp: 'ガノン城のボス部屋のカギ', types: ["ganon", "deku", "bosskey"], child: "yes" },
+  { name: "Defeat Queen Gohma", jp: 'ゴーマ撃破', types: ["deku", "ganon"], child: "yes" },
+  { name: "Milk", jp: 'ロンロン牛乳', types: ["lonlon", "bottle"], child: "yes" },
+  { name: "Defeat a White Wolfos", jp: 'ホワイトウルフォス撃破', types: ["ice", "fortress", "ganon"], child: "yes" },
+  { name: "All 3 Kokiri Forest area Skulltulas", jp: 'コキリの森エリアの黄金のスタルチュラ３匹', types: ["forest"], child: "no" },
+  { name: "30 Deku Sticks", jp: 'デクの棒30本', types: ["atrade"], child: "yes" }
+];
+bingoList[6] = [
+  { name: "Ice Cavern Heart Piece", jp: '氷の洞窟のハートのかけら', types: ["ice", "hearts"], child: "yes" },
+  { name: "Plant bean in Death Mountain Crater", jp: 'デスマウンテン火口の土にマメを植える', types: ["dmc", "beans", "child2"], child: "yes" },
+  { name: "Cow in House", jp: '牛(リンクの家)', types: ["cow"], child: "no" },
+  { name: "Beat the Deku Tree", jp: 'デクの樹様の中クリア', types: ["deku", "ganon"], child: "yes" },
+  { name: "3 Tunics", jp: '服3種類', types: ["tunics", "ice", "fire"], child: "no" },
+  { name: "3 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ3つ', types: ["fortress"], child: "yes" },
+  { name: "Epona's Song", jp: 'エポナの歌', types: ["lonlon", "songs"], child: "yes" }
+];
+bingoList[7] = [
+  { name: "All 3 Skulltulas in Ice Cavern", jp: '氷の洞窟の黄金のスタルチュラ3匹', types: ["ice"], child: "yes" },
+  { name: "6 Hearts", jp: 'ハート6つ', types: ["hearts", "barinade", "pganon", "volvagia", "morpha", "bongo", "twinrova"], child: "yes" },
+  { name: "4 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ4つ', types: ["fortress"], child: "yes" },
+  { name: "Water Temple Boss Key", jp: '水の神殿のボス部屋のカギ', types: ["water", "fortress", "bosskey"], child: "no" },
+  { name: "Both Gerudo's Fortress area Skulltulas", jp: 'ゲルドの砦の黄金のスタルチュラ2匹', types: ["fortress"], child: "no" },
+  { name: "All 4 Lost Woods area Skulltulas", jp: '迷いの森エリアの黄金のスタルチュラ4匹', types: ["forest"], child: "no" },
+  { name: "Fill all 4 Bottle Slots", jp: '4つの空きビンスロットを全て埋める', types: ["bottle"], child: "yes" }
+];
+bingoList[8] = [
+  { name: "Blue Potion", jp: '青いクスリ', types: ["atrade", "zl"], child: "no" },
+  { name: "Defeat Morpha", jp: 'モーファ撃破', types: ["water", "morpha"], child: "no" },
+  { name: "Map & Compass in Ice Cavern", jp: '氷の洞窟のマップとコンパス', types: ["ice", "mapcompass"], child: "no" },
+  { name: "Defeat Phantom Ganon", jp: 'ファントムガノン撃破', types: ["forest", "pganon"], child: "yes" },
+  { name: "At least 4 songs", jp: '歌4つ以上', types: ["songs", "atrade", "zl"], child: "yes" },
+  { name: "All 5 Skulltulas in Dodongo's Cavern", jp: 'ドドンゴの洞窟の黄金のスタルチュラ5匹', types: ["dc"], child: "yes" }
+];
+bingoList[9] = [
+  { name: "All 8 Kakariko area Skulltulas", jp: 'カカリコ村エリアの黄金のスタルチュラ8匹', types: ["botw"], child: "no" },
+  { name: "37th heart piece (Child Fortress)", jp: '37番目のハートのかけら(子供のゲルドの砦)', types: ["fortress", "hearts"], child: "yes" },
+  { name: "Beat the Forest Temple", jp: '森の神殿クリア', types: ["forest", "pganon"], child: "yes" },
+  { name: "Defeat Big Octo", jp: '大オクタ撃破', types: ["jabu", "ice"], child: "yes" },
+  { name: "Iron Boots", jp: 'ヘビーブーツ', types: ["ice", "boots"], child: "yes" },
+  { name: "All 3 Skulltulas in Bottom of the Well", jp: '井戸の底の黄金のスタルチュラ3匹', types: ["botw"], child: "yes" },
+  { name: "6 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ6つ', types: ["fortress"], child: "yes" }
+];
+bingoList[10] = [
+  { name: "3 Swords & 3 Tunics", jp: '剣3種類と服3種類', types: ["swords", "tunics", "ice", "fire", "wallet"], child: "no" },
+  { name: "At least 7 Magic Beans", jp: '魔法のマメ7つ以上', types: ["beans"], child: "yes" },
+  { name: "Beat the Water Temple", jp: '水の神殿クリア', types: ["water", "morpha"], child: "no" },
+  { name: "Requiem of Spirit", jp: '魂のレクイエム', types: ["spirit", "songs"], child: "yes" },
+  { name: "3 Boots", jp: '靴3種類', types: ["boots", "ice"], child: "yes" },
+  { name: "All 4 Skulltulas in Deku Tree", jp: 'デクの樹様の中の黄金のスタルチュラ4匹', types: ["deku"], child: "yes" },
+  { name: "Forest Medallion", jp: '森のメダル', types: ["forest", "lightarrow", "atrade", "pganon"], child: "yes" }
+];
+bingoList[11] = [
+  { name: "Map & Compass in Jabu-Jabu", jp: 'ジャブジャブ様のお腹のマップとコンパス', types: ["jabu", "mapcompass"], child: "yes" },
+  { name: "At least 6 songs", jp: '歌6つ以上', types: ["songs", "atrade", "zl"], child: "no" },
+  { name: "7 Hearts", jp: 'ハート7つ', types: ["hearts", "barinade", "pganon", "volvagia", "morpha", "bongo", "twinrova"], child: "yes" },
+  { name: "All 5 Skulltulas in Forest Temple", jp: '森の神殿の黄金のスタルチュラ5匹', types: ["forest"], child: "no" },
+  { name: "Golden Gauntlets", jp: '金のグローブ', types: ["strength", "ganon", "deku"], child: "yes" },
+  { name: "Get Bombchu chest in Spirit Temple", jp: '魂の神殿のボムチュウ取得', types: ["spirit"], child: "yes" },
+  { name: "Stone of Agony", jp: 'もだえ石', types: ["wallet"], child: "yes" }
+];
+bingoList[12] = [
+  { name: "All 4 Skulltulas in Jabu-Jabu", jp: 'ジャブジャブ様のお腹の黄金のスタルチュラ4匹', types: ["jabu", "ice", "barinade"], child: "yes" },
+  { name: "Water Medallion", jp: '水のメダル', types: ["water", "lightarrow", "atrade", "morpha"], child: "no" },
+  { name: "Gerudo's Card", jp: 'ゲルドの会員証', types: ["fortress"], child: "yes" },
+  { name: "Fairy Bow", jp: '妖精の弓', types: ["forest", "quiver"], child: "no" },
+  { name: "Defeat Dark Link", jp: 'ダークリンク撃破', types: ["water", "ice"], child: "no" },
+  { name: "Silver Gauntlets", jp: '銀のグローブ', types: ["strength", "spirit"], child: "yes" },
+  { name: "Bottled Big Poe", jp: 'ビン(ビッグポウ)', types: ["quiver", "forest", "fortress"], child: "no" }
+];
+bingoList[13] = [
+  { name: "All 4 Lon-Lon Ranch area Skulltulas", jp: 'ロンロン牧場エリアの黄金のスタルチュラ4匹', types: ["jabu", "lonlon"], child: "yes" },
+  { name: "Fire Arrow", jp: '炎の矢', types: ["water", "fortress", "firearrow", "quiver"] },
+  { name: "3 Boss Keys", jp: 'ボス部屋のカギ3つ', types: ["bosskey", "claimcheck"], child: "no" },
+  { name: "Defeat Amy (Green Poe)", jp: 'エイミー撃破(緑のポウ)ｴ', types: ["forest", "fortress", "quiver"], child: "no" },
+  { name: "Defeat Barinade", jp: 'バリネード撃破', types: ["jabu", "barinade"], child: "yes" },
+  { name: "All 4 Gerudo Valley area Skulltulas", jp: 'ゲルドの谷エリアの黄金のスタルチュラ4匹', types: ["fortress", "jabu"], child: "no" },
+  { name: "Keaton Mask", jp: 'キータンのお面', types: ["zl"], child: "yes" }
+];
+bingoList[14] = [
+  { name: "Longshot", jp: 'ロングフック', types: ["water", "ice"], child: "no" },
+  { name: "Both Hyrule Field area Skulltulas", jp: 'ハイラル平原エリアの黄金のスタルチュラ2匹', types: ["zl", "water"], child: "yes" },
+  { name: "Mirror Shield", jp: 'ミラーシールド', types: ["shields", "spirit"], child: "yes" },
+  { name: "3 Tunics & 3 Boots", jp: '服3種類と靴3種類', types: ["tunics", "boots", "fire", "ice"], child: "no" },
+  { name: "All 8 Death Mountain area Skulltulas", jp: 'デスマウンテンエリアの黄金のスタルチュラ8匹', types: ["dmc"], child: "no" },
+  { name: "Map & Compass in Forest Temple", jp: '森の神殿のマップとコンパス', types: ["forest", "quiver", "mapcompass"], child: "no" },
+  { name: "Map & Compass in Fire Temple", jp: '炎の神殿のマップとコンパス', types: ["fire", "mapcompass"], child: "no" },
+  { name: "Bombchu Bowling Heart Piece", jp: 'ボムチュウボウリングのハートのかけら', types: ["dc", "hearts"], child: "yes" },
+  { name: "Forest Temple Boss Key", jp: '森の神殿のボス部屋のカギ', types: ["forest", "bosskey", "claimcheck", "quiver"], child: "no" }
+];
+bingoList[15] = [
+  { name: "3 Swords & 3 Boots", jp: '剣3種類と靴3種類', types: ["swords", "boots", "wallet", "ice"], child: "no" },
+  { name: "All 8 Zora's Domain area Skulltulas", jp: 'ゾーラの里エリアの黄金のスタルチュラ8匹', types: ["jabu", "ice"], child: "no" },
+  { name: "At least 8 songs", jp: '歌8つ以上', types: ["songs", "atrade", "zl"], child: "no" },
+  { name: "Double Magic", jp: '魔力2倍', types: ["dmc", "zl"], child: "yes" },
+  { name: "At least 9 Magic Beans", jp: '魔法のマメ9つ以上', types: ["beans"], child: "yes" },
+  { name: "Megaton Hammer", jp: 'メガトンハンマー', types: ["fire"], child: "no" },
+  { name: "Get to the end of Fire Trial", jp: '炎の結界の最後の部屋に到達', types: ["ganon", "strength"], child: "no" },
+  { name: "6 Maps", jp: 'マップ6つ', types: ["mapcompass", "claimcheck", "ice"], child: "yes" }
+];
+bingoList[16] = [
+  { name: "Double Defense", jp: '防御力2倍', types: ["zl", "ganon"], child: "no" },
+  { name: "Defeat both Flare Dancers", jp: 'フレアダンサー2体撃破', types: ["fire"], child: "no" },
+  { name: "Bronze Gauntlets", jp: '銅のグローブ', types: ["strength", "bulletbag", "ganon", "atrade"], child: "no" },
+  { name: "At least 3 Skulltulas in Water Temple", jp: '水の神殿の黄金のスタルチュラ3匹以上', types: ["water", "ice"], child: "no" },
+  { name: "Beat Jabu-Jabu's Belly", jp: 'ジャブジャブ様のお腹クリア', types: ["jabu", "barinade"], child: "yes" },
+  { name: "Saria's Song", jp: 'サリアの歌', types: ["songs", "zl", "saria", "child2"], child: "yes" },
+  { name: "8 Hearts", jp: 'ハート8つ', types: ["hearts", "barinade", "pganon", "volvagia", "morpha", "bongo", "twinrova"], child: "yes" }
+];
+bingoList[17] = [
+  { name: "Frog's Heart Piece", jp: 'カエルのハートのかけら(嵐の歌)', types: ["songs", "forest", "hearts", "child2"], child: "no" },
+  { name: "Farore's Wind", jp: 'フロルの風', types: ["zl", "ice"], child: "yes" },
+  { name: "Map & Compass in Water Temple", jp: '水の神殿のマップとコンパス', types: ["water", "ice", "mapcompass"], child: "no" },
+  { name: "Shadow Temple Boss Key", jp: '闇の神殿のボス部屋のカギ', types: ["shadow", "zl", "bosskey", "bongo"], child: "no" },
+  { name: "Defeat Nabooru-Knuckle", jp: 'アイアンナック(ナボール)撃破', types: ["spirit"], child: "no" },
+  { name: "3 Swords & 3 Shields", jp: '剣3種類と盾3種類', types: ["swords", "wallet", "shields", "spirit"], child: "no" }
+];
+bingoList[18] = [
+  { name: "All 5 Skulltulas in Spirit Temple", jp: '魂の神殿の黄金のスタルチュラ5匹', types: ["spirit", "atrade", "songs"], child: "yes" },
+  { name: "Blue Gauntlets", jp: '青のグローブ', types: ["spirit", "strength", "bulletbag", "atrade"], child: "no" },
+  { name: "All 5 Skulltulas in Fire Temple", jp: '炎の神殿の黄金のスタルチュラ5匹', types: ["fire"], child: "no" },
+  { name: "Get to the end of Light Trial", jp: '光の結界の最後の部屋に到達', types: ["ganon", "zl", "strength"], child: "no" },
+  { name: "Defeat Volvagia", jp: 'ヴァルバジア撃破', types: ["fire", "volvagia"], child: "no" },
+  { name: "Defeat Bongo-Bongo", jp: 'ボンゴボンゴ撃破', types: ["shadow", "zl", "deku", "bongo"], child: "no" }
+];
+bingoList[19] = [
+  { name: "All 4 Wasteland/ Colossus area Skulltulas", jp: '幻影の砂漠・巨大邪神像エリアの黄金のスタルチュラ4匹', types: ["spirit"], child: "no" },
+  { name: "At least 9 songs", jp: '歌9つ以上', types: ["songs", "atrade", "zl"], child: "no" },
+  { name: "3 Shields & 3 Tunics", jp: '盾3種類と服3種類', types: ["shields", "fire", "tunics", "spirit"], child: "no" },
+  { name: "7 Maps", jp: 'マップ7つ', types: ["mapcompass", "claimcheck", "ice"], child: "yes" },
+  { name: "6 Compasses", jp: 'コンパス6つ', types: ["mapcompass", "ice"], child: "yes" },
+  { name: "Goron Bracelet", jp: 'ゴロンの腕輪', types: ["strength", "zl", "saria", "child2"], child: "yes" }
+];
+bingoList[20] = [
+  { name: "8 different unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用の異なる鍵8つ', types: ["fortress", "strength", "quiver"], child: "no" },
+  { name: "Din's Fire", jp: 'ディンの炎', types: ["zl"], child: "yes" },
+  { name: "Nayru's Love", jp: 'ネールの愛', types: ["spirit", "zl"], child: "yes" },
+  { name: "Both heart pieces in Lost Woods", jp: '迷いの森のハートのかけら２つ', types: ["songs", "zl", "hearts"], child: "yes" },
+  { name: "All 5 Lake Hylia Skulltulas", jp: 'ハイリア湖畔エリアの黄金のスタルチュラ5匹', types: ["ice", "water", "child2"], child: "no" },
+  { name: "Beat the Shadow Temple", jp: '闇の神殿クリア', types: ["shadow", "zl", "deku", "bongo"], child: "no" }
+];
+bingoList[21] = [
+  { name: "Beat the Fire Temple", jp: '炎の神殿クリア', types: ["fire", "forest", "volvagia"], child: "no" },
+  { name: "Free all 9 gorons in Fire Temple", jp: '炎の神殿で９人のゴロンを全員救う', types: ["fire"], child: "no" },
+  { name: "9 Hearts", jp: 'ハート9つ', types: ["hearts", "saria", "barinade", "pganon", "volvagia", "morpha", "bongo", "twinrova"], child: "yes" },
+  { name: "Spooky Mask", jp: 'こわそなお面', types: ["zl", "fortress", "saria", "beans"], child: "yes" },
+  { name: "Defeat Meg (purple Poe)", jp: 'メグ撃破(紫のポウ)', types: ["forest", "quiver"], child: "no" }
+];
+bingoList[22] = [
+  { name: "Light Arrows", jp: '光の矢', types: ["lightarrow", "atrade", "zl"], child: "no" },
+  { name: "3 Shields & 3 Boots", jp: '盾3種類と靴3種類', types: ["shields", "boots", "spirit", "ice"], child: "yes" },
+  { name: "Get to the end of Water Trial", jp: '水の結界の最後の部屋に到達', types: ["ganon", "fire", "lightarrow"], child: "no" },
+  { name: "All 4 Market area Skulltulas", jp: '城下町エリアの黄金のスタルチュラ4匹', types: ["forest", "pganon", "child2"], child: "no" },
+  { name: "Map & Compass in Spirit Temple", jp: '魂の神殿のマップとコンパス', types: ["spirit", "zl", "mapcompass"], child: "yes" }
+];
+bingoList[23] = [
+  { name: "Defeat Twinrova", jp: 'ツインローバ撃破', types: ["spirit", "twinrova"], child: "no" },
+  { name: "Quiver (50)", jp: '矢立て(50)', types: ["quiver", "fortress"], child: "no" },
+  { name: "Spirit Temple Boss Key", jp: '魂の神殿のボス部屋のカギ', types: ["spirit", "lightarrow", "zl", "bosskey"], child: "no" },
+  { name: "7 Compasses", jp: 'コンパス7つ', types: ["mapcompass", "ice"], child: "no" }
+];
+bingoList[24] = [
+  { name: "Two Fairy Spells", jp: '魔法のアイテム２つ', types: ["zl", "spirit"], child: "yes" },
+  { name: "Beat the Spirit Temple", jp: '魂の神殿クリア', types: ["spirit", "twinrova"], child: "no" },
+  { name: "All 5 Skulltulas in Shadow Temple", jp: '闇の神殿の黄金のスタルチュラ5匹', types: ["shadow", "zl"], child: "no" },
+  { name: "Get to the end of Spirit Trial", jp: '魂の結界の最後の部屋に到達', types: ["ganon", "spirit", "quiver"], child: "no" }
+];
+bingoList[25] = [
+  { name: "Green Gauntlets", jp: '緑のグローブ', types: ["strength", "bulletbag", "zl", "atrade", "saria"], child: "no" },
+  { name: "Get to the end of the Forest Trial", jp: '森の結界の最後の部屋に到達', types: ["ganon", "zl", "firearrow"], child: "yes" },
+  { name: "All 5 Skulltulas in Water Temple", jp: '水の神殿の黄金のスタルチュラ5匹', types: ["water"], child: "no" },
+  { name: "Get to the end of Shadow Trial", jp: '闇の結界の最後の部屋に到達', types: ["ganon", "fire"], child: "no" }
+];

--- a/versions/v8/v8.2/generator.js
+++ b/versions/v8/v8.2/generator.js
@@ -1,0 +1,314 @@
+//NOTICE: As of version 6, this script will only generate cards correctly for Ocarina of Time bingo
+//and as shuch should be saved alongside the regular bingo script.
+ootBingoGenerator = function(bingoList, opts) {
+	if(!opts) opts = {};
+	var LANG = opts.lang || 'name';
+	var SEED = opts.seed || Math.ceil(999999 * Math.random()).toString();
+	Math.seedrandom(SEED);
+	var MODE = opts.mode || 'normal';
+  
+	//giuocob 16-8-12: lineCheckList[] has been replaced to allow for removal of all-child rows
+	//Note: the rowElements relation is simply the inverse of the rowCheckList relation
+	var rowElements = {};
+	rowElements["row1"] = [1,2,3,4,5];
+	rowElements["row2"] = [6,7,8,9,10];
+	rowElements["row3"] = [11,12,13,14,15];
+	rowElements["row4"] = [16,17,18,19,20];
+	rowElements["row5"] = [21,22,23,24,25];
+	rowElements["col1"] = [1,6,11,16,21];
+	rowElements["col2"] = [2,7,12,17,22];
+	rowElements["col3"] = [3,8,13,18,23];
+	rowElements["col4"] = [4,9,14,19,24];
+	rowElements["col5"] = [5,10,15,20,25];
+	rowElements["tlbr"] = [1,7,13,19,25];
+	rowElements["bltr"] = [5,9,13,17,21];
+
+	//Given an object that maps keys to flat arrays, invert said object
+	function invertObject(obj) {
+		var ret = {};
+		Object.keys(obj).forEach(function(key) {
+			obj[key].forEach(function(item) {
+				if(!ret[item]) ret[item] = [];
+				ret[item].push(key);
+			});
+		});
+		return ret;
+	}
+
+	rowCheckList = invertObject(rowElements);
+
+
+
+
+	//Main entry point
+	function makeCard() {
+		var bingoBoard = []; //the board itself stored as an array first
+		for (var i=1;i<=25;i++) {
+			if(MODE == "short")
+			{
+		        bingoBoard[i] = {difficulty: difficulty(i), child: "yes"};
+		    }
+		    else
+		    {
+				bingoBoard[i] = {difficulty: difficulty(i), child: "no"};
+			}
+		}                                          // in order 1-25
+	  
+	  
+	    //giuocob 19-2-13: bingoBoard is no longer populated left to right:
+	    //It is now populated mostly randomly, with high difficult goals and
+	    //goals on the diagonals out in front
+	    var populationOrder = [];
+	    populationOrder[1] = 13;   //Populate center first
+	    var diagonals = [1,7,19,25,5,9,17,21];
+	    shuffle(diagonals);
+	    populationOrder = populationOrder.concat(diagonals);   //Next populate diagonals
+	    var nondiagonals = [2,3,4,6,8,10,11,12,14,15,16,18,20,22,23,24];
+	    shuffle(nondiagonals);
+	    populationOrder = populationOrder.concat(nondiagonals);   //Finally add the rest of the squares
+	    //Lastly, find location of difficulty 23,24,25 elements and put them out front
+	    for(var k=23;k<=25;k++)
+	    {
+			var currentSquare = getDifficultyIndex(k);
+			if(currentSquare == 0) continue;
+			for(var i=1;i<25;i++)
+			{
+				if(populationOrder[i] == currentSquare)
+				{
+					populationOrder.splice(i,1);
+					break;
+				}
+			}
+			populationOrder.splice(1,0,currentSquare);
+		}
+
+	    
+	  
+	    //Populate the bingo board in the array
+	    //giuocob 16-8-12: changed this section to:
+	    //1. Support uniform goal selection by shuffling arrays before checking goals
+	    //2. Remove all child rows by checking child tag
+	    //3. If no goal is suitable, instead of choosing goal with lowest synergy, now next difficulty up is checked
+	    for(var i=1;i<=25;i++)
+	    {
+			var sq = populationOrder[i];
+			var getDifficulty = bingoBoard[sq].difficulty;
+			var goalArray = getShuffledGoals(getDifficulty);
+			var j=0, synergy=0, spill = 0, currentObj=null, minSynObj=null;
+			do
+			{
+				currentObj = goalArray[j];
+				synergy = checkLine(sq,currentObj);
+				if(minSynObj == null || synergy < minSynObj.synergy)
+				{
+					minSynObj = {synergy: synergy, value: currentObj};
+				}
+				j++;
+				if(j >= goalArray.length)
+				{
+					getDifficulty++;
+					spill++;
+					if(getDifficulty > 25) {
+						return false;  //HIT THE PANIC BUTTON, RUN FOR THE HILLS
+					} else if(spill >=3) {
+						return false;  //THIS BINGO CARD IS IN UNACCEPTABLE CONDITION
+					} else {
+					    goalArray = getShuffledGoals(getDifficulty);
+					    j = 0;
+					}
+				}
+			} while(synergy != 0);   //Perhaps increase to 1 if difficulty increases happen too often
+			
+	    
+		    bingoBoard[sq].types = minSynObj.value.types;
+		    bingoBoard[sq].subtypes = minSynObj.value.subtypes;
+		    bingoBoard[sq].name = minSynObj.value[LANG] || minSynObj.value.name;
+		    bingoBoard[sq].child = minSynObj.value.child;
+		    bingoBoard[sq].synergy = minSynObj.synergy;
+	    }
+
+	    return bingoBoard;
+
+
+
+
+    	function mirror(i) {
+			if      (i == 0) { i = 4; }
+			else if (i == 1) { i = 3; }
+			else if (i == 3) { i = 1; }
+			else if (i == 4) { i = 0; }
+			return i;
+		}
+
+		function difficulty(i) {
+			// To create the magic square we need 2 random orderings of the numbers 0, 1, 2, 3, 4.
+			// The following creates those orderings and calls them Table5 and Table1
+			
+			var Num3 = SEED%1000;	// Table5 will use the ones, tens, and hundreds digits.
+
+			var Rem8 = Num3%8;
+			var Rem4 = Math.floor(Rem8/2);
+			var Rem2 = Rem8%2;
+			var Rem5 = Num3%5;
+			var Rem3 = Num3%3;	// Note that Rem2, Rem3, Rem4, and Rem5 are mathematically independent.
+			var RemT = Math.floor(Num3/120);	// This is between 0 and 8		
+
+			// The idea is to begin with an array containing a single number, 0.
+			// Each number 1 through 4 is added in a random spot in the array's current size.
+			// The result - the numbers 0 to 4 are in the array in a random (and uniform) order.
+			var Table5 = [0];
+			Table5.splice(Rem2, 0, 1);
+			Table5.splice(Rem3, 0, 2);
+			Table5.splice(Rem4, 0, 3);
+			Table5.splice(Rem5, 0, 4);
+
+			Num3 = Math.floor(SEED/1000);	// Table1 will use the next 3 digits.
+			Num3 = Num3%1000;
+
+			Rem8 = Num3%8;
+			Rem4 = Math.floor(Rem8/2);
+			Rem2 = Rem8%2;
+			Rem5 = Num3%5;
+			Rem3 = Num3%3;
+			RemT = RemT * 8 + Math.floor(Num3/120);	 // This is between 0 and 64.
+
+			var Table1 = [0];
+			Table1.splice(Rem2, 0, 1);
+			Table1.splice(Rem3, 0, 2);
+			Table1.splice(Rem4, 0, 3);
+			Table1.splice(Rem5, 0, 4);
+
+			i--;
+			RemT = RemT%5;		//  Between 0 and 4, fairly uniformly.
+			x = (i+RemT)%5;		//  RemT is horizontal shift to put any diagonal on the main diagonal.
+			y = Math.floor(i/5);
+
+			// The Tables are set into a single magic square template
+			// Some are the same up to some rotation, reflection, or row permutation.
+			// However, all genuinely different magic squares can arise in this fashion.
+			var e5 = Table5[(x + 3*y)%5];
+			var e1 = Table1[(3*x + y)%5];
+
+			// Table5 controls the 5* part and Table1 controls the 1* part.
+			value = 5*e5 + e1;
+
+			if (MODE == "short") { value = Math.floor(value/2); } // if short mode, limit difficulty
+		    	else if (MODE == "long") { value = Math.floor((value + 25) / 2); }
+		    	value++;
+			return value;
+		}
+
+		//Uniformly shuffles an array (note: the original array will be changed)
+		function shuffle(toShuffle)
+		{
+			for(var i=0;i<toShuffle.length;i++)
+			{
+				var randElement = Math.floor(Math.random()*(i+1));
+				var temp = toShuffle[i];
+				toShuffle[i] = toShuffle[randElement];
+				toShuffle[randElement] = temp;
+			}
+		}
+
+		//Get a uniformly shuffled array of all the goals of a given difficulty tier
+		function getShuffledGoals(difficulty)
+		{
+			var newArray = bingoList[difficulty].slice();
+			shuffle(newArray);
+			return newArray;
+		}
+
+		//Given a difficulty as an argument, find the square that contains that difficulty
+		function getDifficultyIndex(difficulty)
+		{
+			for(var i=1;i<=25;i++)
+			{
+				if(bingoBoard[i].difficulty == difficulty)
+				{
+					return i;
+				}
+			}
+			return 0;
+		}
+		  
+
+
+		function checkLine(i, testsquare)
+		{
+			var typesA = testsquare.types || [];
+			var subtypesA = testsquare.subtypes || [];
+			var synergy = 0;
+			var rows = rowCheckList[i], elements = [];
+			var childCount = 0;
+			for(var k=0;k<rows.length;k++)
+			{
+				elements = rowElements[rows[k]];
+				childCount = 0;
+				for(var m=0;m<elements.length;m++)
+				{
+					var testsquare2 = bingoBoard[elements[m]];
+					var typesB = testsquare2.types || [];
+					var subtypesB = testsquare2.subtypes || [];
+					if(typeof typesB != 'undefined')
+					{
+						function matchArrays(arr1, arr2) {
+							for(var n=0;n<arr1.length;n++) {
+								for(var p=0;p<arr2.length;p++) {
+									if(arr1[n] == arr2[p]) synergy++;
+								}
+							}
+						}
+
+						matchArrays(typesA, typesB);
+						matchArrays(typesA, subtypesB);
+						matchArrays(subtypesA, typesB);
+					}
+					if(bingoBoard[elements[m]].child == "yes")
+					{
+						childCount++;
+					}
+				}
+				//Remove child-only rows, remove adult goals from short
+				if(MODE == "short")
+				{
+					if(testsquare.child == "no")
+					{
+						childCount--;
+					}
+					if(childCount < 5)
+					{
+						synergy += 3;
+					}
+				}
+				else
+				{
+					if(testsquare.child == "yes")
+					{
+						childCount++;
+					}
+					if(childCount > 4)
+					{
+						synergy += 3;
+					}
+				}
+			}
+			return synergy;
+		}
+	}
+
+
+	//Loop over cards until one is accepted.
+	var card;
+	var iterations = 0;
+	while(true) {
+		iterations++;
+		card = makeCard();
+		if(card === false) {
+			continue;
+		} else {
+			break;
+		}
+	}
+  
+  	return card;
+}

--- a/versions/v8/v8.2/goal-list.js
+++ b/versions/v8/v8.2/goal-list.js
@@ -1,0 +1,213 @@
+var bingoList = [];
+bingoList["info"] = {
+  version: "v8.2"
+};
+bingoList[1] = [
+  { name: "Bottled Fairy", jp: 'ビン(妖精)', types: ["bottle"], child: "yes" },
+  { name: "Bullet Bag (50)", jp: 'デクのタネ袋(50)', types: ["bulletbag"], child: "yes" },
+  { name: "Lens of Truth", jp: 'まことのメガネ', types: ["botw"], child: "yes" },
+  { name: "Defeat a Skull Kid", jp: 'スタルキッド撃破', types: ["skullkid"], child: "no" },
+  { name: "Map & Compass in Dodongo's Cavern", jp: 'ドドンゴの洞窟のマップとコンパス', types: ["dc"], subtypes: ["mapcompass"], child: "yes" },
+  { name: "At least 30 Deku Nuts", jp: 'デクの実30個以上', types: ["nuts"], child: "yes" }
+];
+bingoList[2] = [
+  { name: "Map & Compass in Deku Tree", jp: 'デクの樹様の中のマップとコンパス', types: ["deku"], subtypes: ["mapcompass"], child: "yes" },
+  { name: "Map & Compass in Bottom of the Well", jp: '井戸の底のマップとコンパス', types: ["botw"], subtypes: ["mapcompass"], child: "yes" },
+  { name: "Giant's Knife", jp: '巨人のナイフ', types: ["swords"], subtypes: ["wallet"], child: "no" },
+  { name: "Bomb Bag (30)", jp: 'ボム袋(30)', types: ["bombbag"], child: "yes" },
+  { name: "Minuet of Forest", jp: '森のメヌエット', types: ["forest"], subtypes: ["songs"], child: "no" },
+  { name: "Zora Tunic", jp: 'ゾーラの服', types: ["tunics", "ice"], child: "no" }
+];
+bingoList[3] = [
+  { name: "Fairy Slingshot", jp: '妖精のパチンコ', types: ["bulletbag", "deku"], child: "yes" },
+  { name: "Goron Tunic", jp: 'ゴロンの服', types: ["tunics", "dmc", "fire"], child: "no" },
+  { name: "Defeat King Dodongo", jp: 'キングドドンゴ撃破', types: ["dc"], subtypes: ["hearts"], child: "yes" },
+  { name: "At least 3 songs", jp: '歌3つ以上', types: ["songs", "zl"], child: "yes" },
+  { name: "Quiver (40)", jp: '矢立て(40)', types: ["atrade", "forest", "quiver"], child: "no" },
+  { name: "Defeat all Lizalfos in Dodongo's Cavern", jp: 'ドドンゴの洞窟のリザルフォス全て撃破', types: ["dc"], child: "yes" }
+];
+bingoList[4] = [
+  { name: "Blue Fire", jp: '青い炎', types: ["ice", "bottle", "ganon"], child: "yes" },
+  { name: "Ruto's Letter", jp: 'ルトの手紙', types: ["bottle"], child: "yes" },
+  { name: "Bullet Bag (40)", jp: 'デクのタネ袋(40)', types: ["bulletbag", "deku"], child: "yes" },
+  { name: "Both heart pieces in Death Mountain Crater", jp: 'デスマウンテン火口のハートのかけら２つ', types: ["dmc", "fire"], subtypes: ["hearts"], child: "yes" },
+  { name: "Ice Arrows", jp: '氷の矢', types: ["fortress", "quiver"], child: "yes" },
+  { name: "Map & Compass in Shadow Temple", jp: '闇の神殿のマップとコンパス', types: ["shadow"], subtypes: ["mapcompass"], child: "yes" },
+  { name: "Bolero of Fire", jp: '炎のボレロ', types: ["dmc", "fire"], subtypes: ["songs"], child: "no" }
+];
+bingoList[5] = [
+  { name: "All 3 Skulltulas in Bottom of the Well", jp: '井戸の底の黄金のスタルチュラ3匹', types: ["botw"], subtypes: ["wallet"], child: "yes" },
+  { name: "Beat Dodongo's Cavern", jp: 'ドドンゴの洞窟クリア', types: ["dc", "fortress"], child: "yes" },
+  { name: "Fire Temple Boss Key", jp: '炎の神殿のボス部屋のカギ', types: ["fire"], subtypes: ["bosskey"], child: "no" },
+  { name: "Ganon's Castle Boss Key", jp: 'ガノン城のボス部屋のカギ', types: ["ganon", "deku"], subtypes: ["bosskey"], child: "yes" },
+  { name: "Defeat Queen Gohma", jp: 'ゴーマ撃破', types: ["deku", "ganon"], subtypes: ["hearts"], child: "yes" },
+  { name: "Defeat a White Wolfos", jp: 'ホワイトウルフォス撃破', types: ["ice", "fortress"], subtypes: ["mapcompass"], child: "yes" },
+  { name: "All 3 Kokiri Forest area Skulltulas", jp: 'コキリの森エリアの黄金のスタルチュラ３匹', types: ["forest"], subtypes: ["wallet"], child: "no" },
+  { name: "30 Deku Sticks", jp: 'デクの棒30本', types: ["atrade"], child: "yes" }
+];
+bingoList[6] = [
+  { name: "Milk", jp: 'ロンロン牛乳', types: ["lonlon", "bottle"], child: "yes" },
+  { name: "Ice Cavern Heart Piece", jp: '氷の洞窟のハートのかけら', types: ["ice"], subtypes: ["hearts", "mapcompass"], child: "yes" },
+  { name: "Plant bean in Death Mountain Crater", jp: 'デスマウンテン火口の土にマメを植える', types: ["dmc", "beans"], subtypes: ["child2"], child: "yes" },
+  { name: "Cow in House", jp: '牛(リンクの家)', types: ["cow"], child: "no" },
+  { name: "Beat the Deku Tree", jp: 'デクの樹様の中クリア', types: ["deku", "ganon"], child: "yes" },
+  { name: "3 Tunics", jp: '服3種類', types: ["tunics", "ice", "fire"], child: "no" },
+  { name: "3 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ3つ', types: ["fortress"], child: "yes" }
+];
+bingoList[7] = [
+  { name: "4 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ4つ', types: ["fortress"], child: "yes" },
+  { name: "At least 7 Magic Beans", jp: '魔法のマメ7つ以上', types: ["beans"], subtypes: ["child2", "wallet"], child: "yes" },
+  { name: "All 3 Skulltulas in Ice Cavern", jp: '氷の洞窟の黄金のスタルチュラ3匹', types: ["ice"], subtypes: ["wallet", "mapcompass"], child: "yes" },
+  { name: "Water Temple Boss Key", jp: '水の神殿のボス部屋のカギ', types: ["water", "fortress"], subtypes: ["bosskey"], child: "no" },
+  { name: "Both Gerudo's Fortress area Skulltulas", jp: 'ゲルドの砦の黄金のスタルチュラ2匹', types: ["fortress"], subtypes: ["wallet"], child: "no" },
+  { name: "All 4 Lost Woods area Skulltulas", jp: '迷いの森エリアの黄金のスタルチュラ4匹', types: ["forest"], subtypes: ["wallet"], child: "no" },
+  { name: "Fill all 4 Bottle Slots", jp: '4つの空きビンスロットを全て埋める', types: ["bottle"], child: "yes" },
+  { name: "Epona's Song", jp: 'エポナの歌', types: ["lonlon"], subtypes: ["songs"], child: "yes" }
+];
+bingoList[8] = [
+  { name: "5 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ5つ', types: ["fortress"], child: "yes" },
+  { name: "6 Hearts", jp: 'ハート6つ', types: ["hearts"], child: "yes" },
+  { name: "Blue Potion", jp: '青いクスリ', types: ["atrade", "zl"], child: "no" },
+  { name: "Map & Compass in Ice Cavern", jp: '氷の洞窟のマップとコンパス', types: ["ice"], subtypes: ["mapcompass"], child: "yes" },
+  { name: "Defeat Phantom Ganon", jp: 'ファントムガノン撃破', types: ["forest"], subtypes: ["hearts"], child: "yes" },
+  { name: "At least 4 songs", jp: '歌4つ以上', types: ["songs", "atrade", "zl"], child: "yes" },
+  { name: "All 5 Skulltulas in Dodongo's Cavern", jp: 'ドドンゴの洞窟の黄金のスタルチュラ5匹', types: ["dc"], subtypes: ["wallet"], child: "yes" }
+];
+bingoList[9] = [
+  { name: "Defeat Morpha", jp: 'モーファ撃破', types: ["water"], subtypes: ["hearts"], child: "no" },
+  { name: "All 8 Kakariko area Skulltulas", jp: 'カカリコ村エリアの黄金のスタルチュラ8匹', types: ["botw"], subtypes: ["wallet"], child: "no" },
+  { name: "37th heart piece (Child Fortress)", jp: '37番目のハートのかけら(子供のゲルドの砦)', types: ["fortress"], subtypes: ["hearts"], child: "yes" },
+  { name: "Beat the Forest Temple", jp: '森の神殿クリア', types: ["forest"], subtypes: ["hearts"], child: "yes" },
+  { name: "Defeat Big Octo", jp: '大オクタ撃破', types: ["jabu", "ice"], child: "yes" },
+  { name: "Iron Boots", jp: 'ヘビーブーツ', types: ["ice", "boots", "mapcompass"], child: "yes" }
+];
+bingoList[10] = [
+  { name: "3 Swords & 3 Tunics", jp: '剣3種類と服3種類', types: ["swords", "tunics", "ice", "fire"], subtypes: ["wallet"], child: "no" },
+  { name: "Beat the Water Temple", jp: '水の神殿クリア', types: ["water"], subtypes: ["hearts"], child: "no" },
+  { name: "3 Boots", jp: '靴3種類', types: ["boots", "ice", "mapcompass"], child: "yes" },
+  { name: "All 4 Skulltulas in Deku Tree", jp: 'デクの樹様の中の黄金のスタルチュラ4匹', types: ["deku"], subtypes: ["wallet"], child: "yes" },
+  { name: "Forest Medallion", jp: '森のメダル', types: ["forest", "lightarrow", "atrade", "zl"], subtypes: ["hearts"], child: "yes" },
+  { name: "6 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ6つ', types: ["fortress"], child: "yes" }
+];
+bingoList[11] = [
+  { name: "Giant's Wallet", jp: '巨人のサイフ', types: ["wallet"], child: "yes" },
+  { name: "Requiem of Spirit", jp: '魂のレクイエム', types: ["spirit"], subtypes: ["songs"], child: "yes" },
+  { name: "Map & Compass in Jabu-Jabu", jp: 'ジャブジャブ様のお腹のマップとコンパス', types: ["jabu"], subtypes: ["mapcompass"], child: "yes" },
+  { name: "At least 6 songs", jp: '歌6つ以上', types: ["songs", "atrade", "zl"], child: "no" },
+  { name: "All 5 Skulltulas in Forest Temple", jp: '森の神殿の黄金のスタルチュラ5匹', types: ["forest"], subtypes: ["wallet"], child: "no" },
+  { name: "Golden Gauntlets", jp: '金のグローブ', types: ["strength", "ganon", "deku"], child: "yes" },
+  { name: "Stone of Agony", jp: 'もだえ石', types: ["wallet"], child: "yes" }
+];
+bingoList[12] = [
+  { name: "Bombchu Bowling Heart Piece", jp: 'ボムチュウボウリングのハートのかけら', types: ["dc"], subtypes: ["hearts", "child2"], child: "yes" },
+  { name: "7 Hearts", jp: 'ハート7つ', types: ["hearts"], child: "yes" },
+  { name: "Get Bombchu chest in Spirit Temple", jp: '魂の神殿のボムチュウ取得', types: ["spirit"], child: "yes" },
+  { name: "All 4 Skulltulas in Jabu-Jabu", jp: 'ジャブジャブ様のお腹の黄金のスタルチュラ4匹', types: ["jabu", "ice"], subtypes: ["hearts", "wallet"], child: "yes" },
+  { name: "Water Medallion", jp: '水のメダル', types: ["water", "lightarrow", "atrade", "zl"], subtypes: ["hearts"], child: "no" },
+  { name: "Gerudo's Card", jp: 'ゲルドの会員証', types: ["fortress"], child: "yes" },
+  { name: "Fairy Bow", jp: '妖精の弓', types: ["forest", "quiver"], subtypes: ["mapcompass", "bosskey"], child: "no" },
+  { name: "Defeat Dark Link", jp: 'ダークリンク撃破', types: ["water", "ice"], child: "no" }
+];
+bingoList[13] = [
+  { name: "Get to the end of Fire Trial", jp: '炎の結界の最後の部屋に到達', types: ["ganon", "strength", "fire"], subtypes: ["bosskey"], child: "no" },
+  { name: "Mirror Shield", jp: 'ミラーシールド', types: ["shields", "spirit"], child: "yes" },
+  { name: "Both Hyrule Field area Skulltulas", jp: 'ハイラル平原エリアの黄金のスタルチュラ2匹', types: ["zl", "water"], subtypes: ["wallet"], child: "yes" },
+  { name: "All 4 Lon-Lon Ranch area Skulltulas", jp: 'ロンロン牧場エリアの黄金のスタルチュラ4匹', types: ["jabu", "lonlon"], subtypes: ["wallet"], child: "yes" },
+  { name: "Fire Arrow", jp: '炎の矢', types: ["water", "fortress", "firearrow", "quiver"] },
+  { name: "Defeat Amy (Green Poe)", jp: 'エイミー撃破(緑のポウ)ｴ', types: ["forest", "fortress", "quiver"], subtypes: ["mapcompass", "bosskey"], child: "no" },
+  { name: "Defeat Barinade", jp: 'バリネード撃破', types: ["jabu"], subtypes: ["hearts"], child: "yes" },
+  { name: "All 4 Gerudo Valley area Skulltulas", jp: 'ゲルドの谷エリアの黄金のスタルチュラ4匹', types: ["fortress", "jabu"], subtypes: ["wallet"], child: "no" },
+  { name: "Keaton Mask", jp: 'キータンのお面', types: ["zl"], child: "yes" }
+];
+bingoList[14] = [
+  { name: "Silver Gauntlets", jp: '銀のグローブ', types: ["strength", "spirit"], child: "yes" },
+  { name: "Longshot", jp: 'ロングフック', types: ["water", "ice"], child: "no" },
+  { name: "At least 9 Magic Beans", jp: '魔法のマメ9つ以上', types: ["beans"], subtypes: ["child2", "wallet"], child: "yes" },
+  { name: "3 Tunics & 3 Boots", jp: '服3種類と靴3種類', types: ["tunics", "boots", "fire", "ice"], subtypes: ["mapcompass"], child: "no" },
+  { name: "All 8 Death Mountain area Skulltulas", jp: 'デスマウンテンエリアの黄金のスタルチュラ8匹', types: ["dmc"], subtypes: ["child2", "wallet"], child: "no" },
+  { name: "Map & Compass in Forest Temple", jp: '森の神殿のマップとコンパス', types: ["forest", "quiver"], subtypes: ["mapcompass", "bosskey"], child: "no" },
+  { name: "Map & Compass in Fire Temple", jp: '炎の神殿のマップとコンパス', types: ["fire"], subtypes: ["mapcompass", "bosskey"], child: "no" },
+  { name: "Forest Temple Boss Key", jp: '森の神殿のボス部屋のカギ', types: ["forest", "bosskey", "claimcheck", "quiver"], subtypes: ["mapcompass", "bosskey"], child: "no" }
+];
+bingoList[15] = [
+  { name: "500 Rupees", jp: '500ルピー', types: ["wallet"], child: "yes" },
+  { name: "3 Swords & 3 Boots", jp: '剣3種類と靴3種類', types: ["swords", "boots", "ice"], subtypes: ["wallet", "mapcompass"], child: "no" },
+  { name: "All 8 Zora's Domain area Skulltulas", jp: 'ゾーラの里エリアの黄金のスタルチュラ8匹', types: ["jabu", "ice"], subtypes: ["wallet"], child: "no" },
+  { name: "At least 8 songs", jp: '歌8つ以上', types: ["songs", "atrade", "zl"], child: "no" },
+  { name: "Double Magic", jp: '魔力2倍', types: ["dmc", "zl"], child: "yes" },
+  { name: "Megaton Hammer", jp: 'メガトンハンマー', types: ["fire"], subtypes: ["mapcompass", "bosskey"], child: "no" }
+];
+bingoList[16] = [
+  { name: "Blue Gauntlets", jp: '青のグローブ', types: ["spirit", "strength", "bulletbag", "atrade"], subtypes: ["wallet"], child: "no" },
+  { name: "Double Defense", jp: '防御力2倍', types: ["zl", "ganon"], child: "no" },
+  { name: "Defeat both Flare Dancers", jp: 'フレアダンサー2体撃破', types: ["fire"], subtypes: ["mapcompass", "bosskey"], child: "no" },
+  { name: "At least 3 Skulltulas in Water Temple", jp: '水の神殿の黄金のスタルチュラ3匹以上', types: ["water", "ice", "zl"], subtypes: ["wallet"], child: "no" },
+  { name: "Beat Jabu-Jabu's Belly", jp: 'ジャブジャブ様のお腹クリア', types: ["jabu"], subtypes: ["hearts", "child2"], child: "yes" },
+  { name: "Saria's Song", jp: 'サリアの歌', types: ["zl", "saria"], subtypes: ["child2", "songs"], child: "yes" }
+];
+bingoList[17] = [
+  { name: "Bronze Gauntlets", jp: '銅のグローブ', types: ["strength", "bulletbag", "ganon", "atrade"], subtypes: ["wallet"], child: "no" },
+  { name: "Frog's Heart Piece", jp: 'カエルのハートのかけら(嵐の歌)', types: ["forest", "child2"], subtypes: ["hearts", "songs"], child: "no" },
+  { name: "Map & Compass in Water Temple", jp: '水の神殿のマップとコンパス', types: ["water", "ice", "zl"], subtypes: ["mapcompass"], child: "no" },
+  { name: "Shadow Temple Boss Key", jp: '闇の神殿のボス部屋のカギ', types: ["shadow", "zl"], subtypes: ["hearts", "bosskey"], child: "no" },
+  { name: "Defeat Nabooru-Knuckle", jp: 'アイアンナック(ナボール)撃破', types: ["spirit"], child: "no" },
+  { name: "3 Swords & 3 Shields", jp: '剣3種類と盾3種類', types: ["swords", "shields", "spirit"], subtypes: ["wallet"], child: "no" }
+];
+bingoList[18] = [
+  { name: "Farore's Wind", jp: 'フロルの風', types: ["zl", "ice"], child: "yes" },
+  { name: "8 Hearts", jp: 'ハート8つ', types: ["hearts"], child: "yes" },
+  { name: "6 Maps", jp: 'マップ6つ', types: ["mapcompass", "claimcheck"], child: "yes" },
+  { name: "All 5 Skulltulas in Spirit Temple", jp: '魂の神殿の黄金のスタルチュラ5匹', types: ["spirit", "atrade", "zl"], subtypes: ["wallet"], child: "yes" },
+  { name: "All 5 Skulltulas in Fire Temple", jp: '炎の神殿の黄金のスタルチュラ5匹', types: ["fire"], subtypes: ["wallet", "mapcompass", "bosskey"], child: "no" },
+  { name: "Get to the end of Light Trial", jp: '光の結界の最後の部屋に到達', types: ["ganon", "zl", "strength"], child: "no" },
+  { name: "Defeat Volvagia", jp: 'ヴァルバジア撃破', types: ["fire"], subtypes: ["hearts", "mapcompass", "bosskey"], child: "no" }
+];
+bingoList[19] = [
+  { name: "All 5 Lake Hylia Skulltulas", jp: 'ハイリア湖畔エリアの黄金のスタルチュラ5匹', types: ["ice", "water"], subtypes: ["child2", "wallet", "mapcompass"], child: "no" },
+  { name: "All 4 Wasteland/ Colossus area Skulltulas", jp: '幻影の砂漠・巨大邪神像エリアの黄金のスタルチュラ4匹', types: ["spirit"], subtypes: ["child2", "wallet"], child: "no" },
+  { name: "At least 9 songs", jp: '歌9つ以上', types: ["songs", "atrade", "zl"], child: "no" },
+  { name: "3 Shields & 3 Tunics", jp: '盾3種類と服3種類', types: ["shields", "fire", "tunics", "spirit"], child: "no" },
+  { name: "Goron Bracelet", jp: 'ゴロンの腕輪', types: ["strength", "zl", "saria"], subtypes: ["child2"], child: "yes" },
+  { name: "Defeat Bongo-Bongo", jp: 'ボンゴボンゴ撃破', types: ["shadow", "zl", "deku"], subtypes: ["hearts", "bosskey"], child: "no" }
+];
+bingoList[20] = [
+  { name: "Beat the Fire Temple", jp: '炎の神殿クリア', types: ["fire", "forest"], subtypes: ["hearts", "bosskey", "mapcompass"], child: "no" },
+  { name: "8 different unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ8つ', types: ["fortress", "strength", "quiver"], child: "no" },
+  { name: "Din's Fire", jp: 'ディンの炎', types: ["zl"], child: "yes" },
+  { name: "Nayru's Love", jp: 'ネールの愛', types: ["spirit", "zl"], child: "yes" },
+  { name: "Both heart pieces in Lost Woods", jp: '迷いの森のハートのかけら２つ', types: ["zl"], subtypes: ["hearts", "child2", "songs"], child: "yes" },
+  { name: "Beat the Shadow Temple", jp: '闇の神殿クリア', types: ["shadow", "zl", "deku"], subtypes: ["hearts", "bosskey"], child: "no" }
+];
+bingoList[21] = [
+  { name: "6 Compasses", jp: 'コンパス6つ', types: ["mapcompass"], child: "yes" },
+  { name: "All 4 Market area Skulltulas", jp: '城下町エリアの黄金のスタルチュラ4匹', types: ["forest", "child2"], subtypes: ["wallet"], subtypes: ["hearts"], child: "no" },
+  { name: "Free all 9 gorons in Fire Temple", jp: '炎の神殿で９人のゴロンを全員救う', types: ["fire"], subtypes: ["mapcompass", "bosskey"], child: "no" },
+  { name: "Spooky Mask", jp: 'こわそなお面', types: ["zl", "fortress", "saria", "beans"], child: "yes" },
+  { name: "Defeat Meg (purple Poe)", jp: 'メグ撃破(紫のポウ)', types: ["forest", "quiver"], subtypes: ["mapcompass", "bosskey"], child: "no" }
+];
+bingoList[22] = [
+  { name: "Light Arrows", jp: '光の矢', types: ["lightarrow", "atrade", "zl"], child: "no" },
+  { name: "3 Shields & 3 Boots", jp: '盾3種類と靴3種類', types: ["shields", "boots", "spirit", "ice"], subtypes: ["mapcompass"], child: "yes" },
+  { name: "Get to the end of Water Trial", jp: '水の結界の最後の部屋に到達', types: ["ganon", "fire", "lightarrow"], subtypes: ["mapcompass", "bosskey"], child: "no" },
+  { name: "Map & Compass in Spirit Temple", jp: '魂の神殿のマップとコンパス', types: ["spirit", "zl"], subtypes: ["mapcompass"], child: "yes" }
+];
+bingoList[23] = [
+  { name: "9 Hearts", jp: 'ハート9つ', types: ["hearts"], child: "yes" },
+  { name: "7 Maps", jp: 'マップ7つ', types: ["mapcompass", "claimcheck"], child: "yes" },
+  { name: "Defeat Twinrova", jp: 'ツインローバ撃破', types: ["spirit"], subtypes: ["hearts"], child: "no" },
+  { name: "Quiver (50)", jp: '矢立て(50)', types: ["quiver", "fortress", "beans"], child: "no" },
+  { name: "Spirit Temple Boss Key", jp: '魂の神殿のボス部屋のカギ', types: ["spirit", "lightarrow", "zl"], subtypes: ["bosskey"], child: "no" }
+];
+bingoList[24] = [
+  { name: "All 5 Skulltulas in Water Temple", jp: '水の神殿の黄金のスタルチュラ5匹', types: ["water", "dc"], child: "no" },
+  { name: "Beat the Spirit Temple", jp: '魂の神殿クリア', types: ["spirit"], subtypes: ["hearts"], child: "no" },
+  { name: "All 5 Skulltulas in Shadow Temple", jp: '闇の神殿の黄金のスタルチュラ5匹', types: ["shadow", "zl"], subtypes: ["wallet", "bosskey"], child: "no" },
+  { name: "Get to the end of Spirit Trial", jp: '魂の結界の最後の部屋に到達', types: ["ganon", "spirit", "quiver"], child: "no" }
+];
+bingoList[25] = [
+  { name: "Two Fairy Spells", jp: '魔法のアイテム２つ', types: ["zl", "spirit"], child: "yes" },
+  { name: "7 Compasses", jp: 'コンパス7つ', types: ["mapcompass"], child: "no" },
+  { name: "Green Gauntlets", jp: '緑のグローブ', types: ["strength", "bulletbag", "zl", "atrade", "saria"], subtypes: ["wallet"], child: "no" },
+  { name: "Get to the end of the Forest Trial", jp: '森の結界の最後の部屋に到達', types: ["ganon", "zl", "firearrow"], child: "yes" },
+  { name: "Get to the end of Shadow Trial", jp: '闇の結界の最後の部屋に到達', types: ["ganon", "fire"], subtypes: ["mapcompass", "bosskey"], child: "no" }
+];

--- a/versions/v8/v8.3/generator.js
+++ b/versions/v8/v8.3/generator.js
@@ -1,0 +1,314 @@
+//NOTICE: As of version 6, this script will only generate cards correctly for Ocarina of Time bingo
+//and as shuch should be saved alongside the regular bingo script.
+ootBingoGenerator = function(bingoList, opts) {
+	if(!opts) opts = {};
+	var LANG = opts.lang || 'name';
+	var SEED = opts.seed || Math.ceil(999999 * Math.random()).toString();
+	Math.seedrandom(SEED);
+	var MODE = opts.mode || 'normal';
+  
+	//giuocob 16-8-12: lineCheckList[] has been replaced to allow for removal of all-child rows
+	//Note: the rowElements relation is simply the inverse of the rowCheckList relation
+	var rowElements = {};
+	rowElements["row1"] = [1,2,3,4,5];
+	rowElements["row2"] = [6,7,8,9,10];
+	rowElements["row3"] = [11,12,13,14,15];
+	rowElements["row4"] = [16,17,18,19,20];
+	rowElements["row5"] = [21,22,23,24,25];
+	rowElements["col1"] = [1,6,11,16,21];
+	rowElements["col2"] = [2,7,12,17,22];
+	rowElements["col3"] = [3,8,13,18,23];
+	rowElements["col4"] = [4,9,14,19,24];
+	rowElements["col5"] = [5,10,15,20,25];
+	rowElements["tlbr"] = [1,7,13,19,25];
+	rowElements["bltr"] = [5,9,13,17,21];
+
+	//Given an object that maps keys to flat arrays, invert said object
+	function invertObject(obj) {
+		var ret = {};
+		Object.keys(obj).forEach(function(key) {
+			obj[key].forEach(function(item) {
+				if(!ret[item]) ret[item] = [];
+				ret[item].push(key);
+			});
+		});
+		return ret;
+	}
+
+	rowCheckList = invertObject(rowElements);
+
+
+
+
+	//Main entry point
+	function makeCard() {
+		var bingoBoard = []; //the board itself stored as an array first
+		for (var i=1;i<=25;i++) {
+			if(MODE == "short")
+			{
+		        bingoBoard[i] = {difficulty: difficulty(i), child: "yes"};
+		    }
+		    else
+		    {
+				bingoBoard[i] = {difficulty: difficulty(i), child: "no"};
+			}
+		}                                          // in order 1-25
+	  
+	  
+	    //giuocob 19-2-13: bingoBoard is no longer populated left to right:
+	    //It is now populated mostly randomly, with high difficult goals and
+	    //goals on the diagonals out in front
+	    var populationOrder = [];
+	    populationOrder[1] = 13;   //Populate center first
+	    var diagonals = [1,7,19,25,5,9,17,21];
+	    shuffle(diagonals);
+	    populationOrder = populationOrder.concat(diagonals);   //Next populate diagonals
+	    var nondiagonals = [2,3,4,6,8,10,11,12,14,15,16,18,20,22,23,24];
+	    shuffle(nondiagonals);
+	    populationOrder = populationOrder.concat(nondiagonals);   //Finally add the rest of the squares
+	    //Lastly, find location of difficulty 23,24,25 elements and put them out front
+	    for(var k=23;k<=25;k++)
+	    {
+			var currentSquare = getDifficultyIndex(k);
+			if(currentSquare == 0) continue;
+			for(var i=1;i<25;i++)
+			{
+				if(populationOrder[i] == currentSquare)
+				{
+					populationOrder.splice(i,1);
+					break;
+				}
+			}
+			populationOrder.splice(1,0,currentSquare);
+		}
+
+	    
+	  
+	    //Populate the bingo board in the array
+	    //giuocob 16-8-12: changed this section to:
+	    //1. Support uniform goal selection by shuffling arrays before checking goals
+	    //2. Remove all child rows by checking child tag
+	    //3. If no goal is suitable, instead of choosing goal with lowest synergy, now next difficulty up is checked
+	    for(var i=1;i<=25;i++)
+	    {
+			var sq = populationOrder[i];
+			var getDifficulty = bingoBoard[sq].difficulty;
+			var goalArray = getShuffledGoals(getDifficulty);
+			var j=0, synergy=0, spill = 0, currentObj=null, minSynObj=null;
+			do
+			{
+				currentObj = goalArray[j];
+				synergy = checkLine(sq,currentObj);
+				if(minSynObj == null || synergy < minSynObj.synergy)
+				{
+					minSynObj = {synergy: synergy, value: currentObj};
+				}
+				j++;
+				if(j >= goalArray.length)
+				{
+					getDifficulty++;
+					spill++;
+					if(getDifficulty > 25) {
+						return false;  //HIT THE PANIC BUTTON, RUN FOR THE HILLS
+					} else if(spill >=3) {
+						return false;  //THIS BINGO CARD IS IN UNACCEPTABLE CONDITION
+					} else {
+					    goalArray = getShuffledGoals(getDifficulty);
+					    j = 0;
+					}
+				}
+			} while(synergy != 0);   //Perhaps increase to 1 if difficulty increases happen too often
+			
+	    
+		    bingoBoard[sq].types = minSynObj.value.types;
+		    bingoBoard[sq].subtypes = minSynObj.value.subtypes;
+		    bingoBoard[sq].name = minSynObj.value[LANG] || minSynObj.value.name;
+		    bingoBoard[sq].child = minSynObj.value.child;
+		    bingoBoard[sq].synergy = minSynObj.synergy;
+	    }
+
+	    return bingoBoard;
+
+
+
+
+    	function mirror(i) {
+			if      (i == 0) { i = 4; }
+			else if (i == 1) { i = 3; }
+			else if (i == 3) { i = 1; }
+			else if (i == 4) { i = 0; }
+			return i;
+		}
+
+		function difficulty(i) {
+			// To create the magic square we need 2 random orderings of the numbers 0, 1, 2, 3, 4.
+			// The following creates those orderings and calls them Table5 and Table1
+			
+			var Num3 = SEED%1000;	// Table5 will use the ones, tens, and hundreds digits.
+
+			var Rem8 = Num3%8;
+			var Rem4 = Math.floor(Rem8/2);
+			var Rem2 = Rem8%2;
+			var Rem5 = Num3%5;
+			var Rem3 = Num3%3;	// Note that Rem2, Rem3, Rem4, and Rem5 are mathematically independent.
+			var RemT = Math.floor(Num3/120);	// This is between 0 and 8		
+
+			// The idea is to begin with an array containing a single number, 0.
+			// Each number 1 through 4 is added in a random spot in the array's current size.
+			// The result - the numbers 0 to 4 are in the array in a random (and uniform) order.
+			var Table5 = [0];
+			Table5.splice(Rem2, 0, 1);
+			Table5.splice(Rem3, 0, 2);
+			Table5.splice(Rem4, 0, 3);
+			Table5.splice(Rem5, 0, 4);
+
+			Num3 = Math.floor(SEED/1000);	// Table1 will use the next 3 digits.
+			Num3 = Num3%1000;
+
+			Rem8 = Num3%8;
+			Rem4 = Math.floor(Rem8/2);
+			Rem2 = Rem8%2;
+			Rem5 = Num3%5;
+			Rem3 = Num3%3;
+			RemT = RemT * 8 + Math.floor(Num3/120);	 // This is between 0 and 64.
+
+			var Table1 = [0];
+			Table1.splice(Rem2, 0, 1);
+			Table1.splice(Rem3, 0, 2);
+			Table1.splice(Rem4, 0, 3);
+			Table1.splice(Rem5, 0, 4);
+
+			i--;
+			RemT = RemT%5;		//  Between 0 and 4, fairly uniformly.
+			x = (i+RemT)%5;		//  RemT is horizontal shift to put any diagonal on the main diagonal.
+			y = Math.floor(i/5);
+
+			// The Tables are set into a single magic square template
+			// Some are the same up to some rotation, reflection, or row permutation.
+			// However, all genuinely different magic squares can arise in this fashion.
+			var e5 = Table5[(x + 3*y)%5];
+			var e1 = Table1[(3*x + y)%5];
+
+			// Table5 controls the 5* part and Table1 controls the 1* part.
+			value = 5*e5 + e1;
+
+			if (MODE == "short") { value = Math.floor(value/2); } // if short mode, limit difficulty
+		    	else if (MODE == "long") { value = Math.floor((value + 25) / 2); }
+		    	value++;
+			return value;
+		}
+
+		//Uniformly shuffles an array (note: the original array will be changed)
+		function shuffle(toShuffle)
+		{
+			for(var i=0;i<toShuffle.length;i++)
+			{
+				var randElement = Math.floor(Math.random()*(i+1));
+				var temp = toShuffle[i];
+				toShuffle[i] = toShuffle[randElement];
+				toShuffle[randElement] = temp;
+			}
+		}
+
+		//Get a uniformly shuffled array of all the goals of a given difficulty tier
+		function getShuffledGoals(difficulty)
+		{
+			var newArray = bingoList[difficulty].slice();
+			shuffle(newArray);
+			return newArray;
+		}
+
+		//Given a difficulty as an argument, find the square that contains that difficulty
+		function getDifficultyIndex(difficulty)
+		{
+			for(var i=1;i<=25;i++)
+			{
+				if(bingoBoard[i].difficulty == difficulty)
+				{
+					return i;
+				}
+			}
+			return 0;
+		}
+		  
+
+
+		function checkLine(i, testsquare)
+		{
+			var typesA = testsquare.types || [];
+			var subtypesA = testsquare.subtypes || [];
+			var synergy = 0;
+			var rows = rowCheckList[i], elements = [];
+			var childCount = 0;
+			for(var k=0;k<rows.length;k++)
+			{
+				elements = rowElements[rows[k]];
+				childCount = 0;
+				for(var m=0;m<elements.length;m++)
+				{
+					var testsquare2 = bingoBoard[elements[m]];
+					var typesB = testsquare2.types || [];
+					var subtypesB = testsquare2.subtypes || [];
+					if(typeof typesB != 'undefined')
+					{
+						function matchArrays(arr1, arr2) {
+							for(var n=0;n<arr1.length;n++) {
+								for(var p=0;p<arr2.length;p++) {
+									if(arr1[n] == arr2[p]) synergy++;
+								}
+							}
+						}
+
+						matchArrays(typesA, typesB);
+						matchArrays(typesA, subtypesB);
+						matchArrays(subtypesA, typesB);
+					}
+					if(bingoBoard[elements[m]].child == "yes")
+					{
+						childCount++;
+					}
+				}
+				//Remove child-only rows, remove adult goals from short
+				if(MODE == "short")
+				{
+					if(testsquare.child == "no")
+					{
+						childCount--;
+					}
+					if(childCount < 5)
+					{
+						synergy += 3;
+					}
+				}
+				else
+				{
+					if(testsquare.child == "yes")
+					{
+						childCount++;
+					}
+					if(childCount > 4)
+					{
+						synergy += 3;
+					}
+				}
+			}
+			return synergy;
+		}
+	}
+
+
+	//Loop over cards until one is accepted.
+	var card;
+	var iterations = 0;
+	while(true) {
+		iterations++;
+		card = makeCard();
+		if(card === false) {
+			continue;
+		} else {
+			break;
+		}
+	}
+  
+  	return card;
+}

--- a/versions/v8/v8.3/goal-list.js
+++ b/versions/v8/v8.3/goal-list.js
@@ -1,0 +1,213 @@
+var bingoList = [];
+bingoList["info"] = {
+  version: "v8.3"
+};
+bingoList[1] = [
+  { name: "Bottled Fairy", jp: 'ビン(妖精)', types: ["bottle"], child: "yes" },
+  { name: "Bullet Bag (50)", jp: 'デクのタネ袋(50)', types: ["bulletbag"], child: "yes" },
+  { name: "Bomb Bag (30)", jp: 'ボム袋(30)', types: ["bombbag"], child: "yes" },
+  { name: "Lens of Truth", jp: 'まことのメガネ', types: ["botw"], child: "yes" },
+  { name: "Defeat a Skull Kid", jp: 'スタルキッド撃破', types: ["skullkid"], child: "no" },
+  { name: "Map & Compass in Dodongo's Cavern", jp: 'ドドンゴの洞窟のマップとコンパス', types: ["dc"], subtypes: ["mapcompass"], child: "yes" },
+  { name: "At least 30 Deku Nuts", jp: 'デクの実30個以上', types: ["nuts"], child: "yes" }
+];
+bingoList[2] = [
+  { name: "Map & Compass in Deku Tree", jp: 'デクの樹様の中のマップとコンパス', types: ["deku"], subtypes: ["mapcompass"], child: "yes" },
+  { name: "Map & Compass in Bottom of the Well", jp: '井戸の底のマップとコンパス', types: ["botw"], subtypes: ["mapcompass"], child: "yes" },
+  { name: "Giant's Knife", jp: '巨人のナイフ', types: ["swords"], subtypes: ["wallet"], child: "no" },
+  { name: "Minuet of Forest", jp: '森のメヌエット', types: ["forest"], subtypes: ["songs"], child: "no" },
+  { name: "Goron Tunic", jp: 'ゴロンの服', types: ["tunics", "dmc", "fire"], child: "no" },
+  { name: "Zora Tunic", jp: 'ゾーラの服', types: ["tunics", "ice"], child: "no" }
+];
+bingoList[3] = [
+  { name: "Fairy Slingshot", jp: '妖精のパチンコ', types: ["bulletbag", "deku"], child: "yes" },
+  { name: "Defeat King Dodongo", jp: 'キングドドンゴ撃破', types: ["dc"], subtypes: ["hearts"], child: "yes" },
+  { name: "At least 3 songs", jp: '歌3つ以上', types: ["songs", "zl"], child: "yes" },
+  { name: "Quiver (40)", jp: '矢立て(40)', types: ["atrade", "forest", "quiver"], child: "no" },
+  { name: "Defeat all Lizalfos in Dodongo's Cavern", jp: 'ドドンゴの洞窟のリザルフォス全て撃破', types: ["dc"], child: "yes" },
+  { name: "Bolero of Fire", jp: '炎のボレロ', types: ["dmc", "fire"], subtypes: ["songs"], child: "no" },
+  { name: "30 Deku Sticks", jp: 'デクの棒30本', types: ["atrade"], child: "yes" }
+];
+bingoList[4] = [
+  { name: "Ruto's Letter", jp: 'ルトの手紙', types: ["bottle"], child: "yes" },
+  { name: "Bullet Bag (40)", jp: 'デクのタネ袋(40)', types: ["bulletbag", "deku"], child: "yes" },
+  { name: "Both heart pieces in Death Mountain Crater", jp: 'デスマウンテン火口のハートのかけら２つ', types: ["dmc", "fire"], subtypes: ["hearts"], child: "yes" },
+  { name: "Ice Arrows", jp: '氷の矢', types: ["fortress", "quiver"], child: "yes" },
+  { name: "Map & Compass in Shadow Temple", jp: '闇の神殿のマップとコンパス', types: ["shadow"], subtypes: ["mapcompass"], child: "yes" }
+];
+bingoList[5] = [
+  { name: "Blue Fire", jp: '青い炎', types: ["ice", "bottle", "ganon"], child: "yes" },
+  { name: "Beat Dodongo's Cavern", jp: 'ドドンゴの洞窟クリア', types: ["dc", "fortress"], child: "yes" },
+  { name: "Fire Temple Boss Key", jp: '炎の神殿のボス部屋のカギ', types: ["fire"], subtypes: ["bosskey"], child: "no" },
+  { name: "Defeat Queen Gohma", jp: 'ゴーマ撃破', types: ["deku", "ganon"], subtypes: ["hearts"], child: "yes" },
+  { name: "All 3 Kokiri Forest area Skulltulas", jp: 'コキリの森エリアの黄金のスタルチュラ３匹', types: ["forest"], subtypes: ["wallet"], child: "no" },
+  { name: "Ice Cavern Heart Piece", jp: '氷の洞窟のハートのかけら', types: ["ice"], subtypes: ["hearts", "mapcompass"], child: "yes" },
+  { name: "3 Tunics", jp: '服3種類', types: ["tunics", "ice", "fire"], child: "no" }
+];
+bingoList[6] = [
+  { name: "Defeat a White Wolfos", jp: 'ホワイトウルフォス撃破', types: ["ice", "fortress"], subtypes: ["mapcompass"], child: "yes" },
+  { name: "Ganon's Castle Boss Key", jp: 'ガノン城のボス部屋のカギ', types: ["ganon", "deku"], subtypes: ["bosskey"], child: "yes" },
+  { name: "All 3 Skulltulas in Bottom of the Well", jp: '井戸の底の黄金のスタルチュラ3匹', types: ["botw"], subtypes: ["wallet"], child: "yes" },
+  { name: "Milk", jp: 'ロンロン牛乳', types: ["lonlon", "bottle"], child: "yes" },
+  { name: "Plant bean in Death Mountain Crater", jp: 'デスマウンテン火口の土にマメを植える', types: ["dmc", "beans"], subtypes: ["child2"], child: "yes" },
+  { name: "Cow in House", jp: '牛(リンクの家)', types: ["cow"], child: "no" },
+  { name: "Beat the Deku Tree", jp: 'デクの樹様の中クリア', types: ["deku", "ganon"], child: "yes" },
+  { name: "3 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ3つ', types: ["fortress"], child: "yes" },
+  { name: "All 3 Skulltulas in Ice Cavern", jp: '氷の洞窟の黄金のスタルチュラ3匹', types: ["ice"], subtypes: ["wallet", "mapcompass"], child: "yes" },
+  { name: "Water Temple Boss Key", jp: '水の神殿のボス部屋のカギ', types: ["water", "fortress"], subtypes: ["bosskey"], child: "no" }
+];
+bingoList[7] = [
+  { name: "4 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ4つ', types: ["fortress"], child: "yes" },
+  { name: "Both Gerudo's Fortress area Skulltulas", jp: 'ゲルドの砦の黄金のスタルチュラ2匹', types: ["fortress"], subtypes: ["wallet"], child: "no" },
+  { name: "All 4 Lost Woods area Skulltulas", jp: '迷いの森エリアの黄金のスタルチュラ4匹', types: ["forest"], subtypes: ["wallet"], child: "no" },
+  { name: "Fill all 4 Bottle Slots", jp: '4つの空きビンスロットを全て埋める', types: ["bottle"], child: "yes" },
+  { name: "Epona's Song", jp: 'エポナの歌', types: ["lonlon"], subtypes: ["songs"], child: "yes" },
+  { name: "Map & Compass in Ice Cavern", jp: '氷の洞窟のマップとコンパス', types: ["ice"], subtypes: ["mapcompass"], child: "yes" },
+  { name: "Blue Potion", jp: '青いクスリ', types: ["atrade", "zl"], child: "no" },
+  { name: "At least 4 songs", jp: '歌4つ以上', types: ["songs", "atrade", "zl"], subtypes: ["child2"], child: "yes" },
+  { name: "Giant's Wallet", jp: '巨人のサイフ', types: ["wallet"], child: "yes" }
+];
+bingoList[8] = [
+  { name: "At least 7 Magic Beans", jp: '魔法のマメ7つ以上', types: ["beans"], subtypes: ["child2", "wallet"], child: "yes" },
+  { name: "5 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ5つ', types: ["fortress"], child: "yes" },
+  { name: "6 Hearts", jp: 'ハート6つ', types: ["hearts"], child: "yes" },
+  { name: "Defeat Phantom Ganon", jp: 'ファントムガノン撃破', types: ["forest"], subtypes: ["hearts"], child: "yes" },
+  { name: "3 Swords & 3 Tunics", jp: '剣3種類と服3種類', types: ["swords", "tunics", "ice", "fire"], subtypes: ["wallet"], child: "no" },
+  { name: "Map & Compass in Water Temple", jp: '水の神殿のマップとコンパス', types: ["water"], subtypes: ["mapcompass"], child: "no" }
+];
+bingoList[9] = [
+  { name: "All 5 Skulltulas in Dodongo's Cavern", jp: 'ドドンゴの洞窟の黄金のスタルチュラ5匹', types: ["dc"], subtypes: ["wallet"], child: "yes" },
+  { name: "Defeat Morpha", jp: 'モーファ撃破', types: ["water"], subtypes: ["hearts"], child: "no" },
+  { name: "Beat the Forest Temple", jp: '森の神殿クリア', types: ["forest"], subtypes: ["hearts"], child: "yes" },
+  { name: "Defeat Big Octo", jp: '大オクタ撃破', types: ["jabu", "ice"], child: "yes" },
+  { name: "Iron Boots", jp: 'ヘビーブーツ', types: ["ice", "boots", "mapcompass"], child: "yes" },
+  { name: "500 Rupees", jp: '500ルピー', types: ["wallet"], child: "yes" }
+];
+bingoList[10] = [
+  { name: "37th heart piece (Child Fortress)", jp: '37番目のハートのかけら(子供のゲルドの砦)', types: ["fortress"], subtypes: ["hearts"], child: "yes" },
+  { name: "All 8 Kakariko area Skulltulas", jp: 'カカリコ村エリアの黄金のスタルチュラ8匹', types: ["botw"], subtypes: ["wallet"], child: "no" },
+  { name: "Beat the Water Temple", jp: '水の神殿クリア', types: ["water"], subtypes: ["hearts"], child: "no" },
+  { name: "3 Boots", jp: '靴3種類', types: ["boots", "ice", "mapcompass"], child: "yes" },
+  { name: "Forest Medallion", jp: '森のメダル', types: ["forest", "lightarrow", "atrade", "zl"], subtypes: ["hearts"], child: "yes" },
+  { name: "6 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ6つ', types: ["fortress"], child: "yes" },
+  { name: "Requiem of Spirit", jp: '魂のレクイエム', types: ["spirit"], subtypes: ["songs"], child: "yes" },
+  { name: "At least 6 songs", jp: '歌6つ以上', types: ["songs", "atrade", "zl"], subtypes: ["child2"], child: "no" }
+];
+bingoList[11] = [
+  { name: "All 5 Skulltulas in Forest Temple", jp: '森の神殿の黄金のスタルチュラ5匹', types: ["forest"], subtypes: ["wallet"], child: "no" },
+  { name: "All 4 Skulltulas in Deku Tree", jp: 'デクの樹様の中の黄金のスタルチュラ4匹', types: ["deku"], subtypes: ["wallet"], child: "yes" },
+  { name: "Golden Gauntlets", jp: '金のグローブ', types: ["strength", "ganon", "deku"], child: "yes" },
+  { name: "Stone of Agony", jp: 'もだえ石', types: ["wallet"], child: "yes" },
+  { name: "Water Medallion", jp: '水のメダル', types: ["water", "lightarrow", "atrade", "zl"], subtypes: ["hearts"], child: "no" },
+  { name: "Gerudo's Card", jp: 'ゲルドの会員証', types: ["fortress"], child: "yes" },
+  { name: "Defeat Amy (Green Poe)", jp: 'エイミー撃破(緑のポウ)ｴ', types: ["forest", "fortress", "quiver"], subtypes: ["mapcompass", "bosskey"], child: "no" }
+];
+bingoList[12] = [
+  { name: "Map & Compass in Jabu-Jabu", jp: 'ジャブジャブ様のお腹のマップとコンパス', types: ["jabu"], subtypes: ["mapcompass"], child: "yes" },
+  { name: "7 Hearts", jp: 'ハート7つ', types: ["hearts"], child: "yes" },
+  { name: "Get Bombchu chest in Spirit Temple", jp: '魂の神殿のボムチュウ取得', types: ["spirit"], child: "yes" },
+  { name: "All 4 Skulltulas in Jabu-Jabu", jp: 'ジャブジャブ様のお腹の黄金のスタルチュラ4匹', types: ["jabu", "ice"], subtypes: ["hearts", "wallet"], child: "yes" },
+  { name: "Fairy Bow", jp: '妖精の弓', types: ["forest", "quiver"], subtypes: ["mapcompass", "bosskey"], child: "no" },
+  { name: "Defeat Dark Link", jp: 'ダークリンク撃破', types: ["water", "ice"], child: "no" },
+  { name: "Mirror Shield", jp: 'ミラーシールド', types: ["shields", "spirit"], child: "yes" },
+  { name: "Fire Arrow", jp: '炎の矢', types: ["water", "fortress", "firearrow", "quiver"], child: "no" }
+];
+bingoList[13] = [
+  { name: "Bombchu Bowling Heart Piece", jp: 'ボムチュウボウリングのハートのかけら', types: ["dc"], subtypes: ["hearts", "child2"], child: "yes" },
+  { name: "Get to the end of Fire Trial", jp: '炎の結界の最後の部屋に到達', types: ["ganon", "strength", "fire"], subtypes: ["bosskey"], child: "no" },
+  { name: "Both Hyrule Field area Skulltulas", jp: 'ハイラル平原エリアの黄金のスタルチュラ2匹', types: ["zl", "water"], subtypes: ["wallet"], child: "yes" },
+  { name: "All 4 Lon-Lon Ranch area Skulltulas", jp: 'ロンロン牧場エリアの黄金のスタルチュラ4匹', types: ["jabu", "lonlon"], subtypes: ["wallet"], child: "yes" },
+  { name: "Silver Gauntlets", jp: '銀のグローブ', types: ["strength", "spirit"], child: "yes" },
+  { name: "Longshot", jp: 'ロングフック', types: ["water", "ice"], child: "no" },
+  { name: "3 Swords & 3 Boots", jp: '剣3種類と靴3種類', types: ["swords", "boots", "ice"], subtypes: ["wallet", "mapcompass"], child: "no" }
+];
+bingoList[14] = [
+  { name: "All 4 Gerudo Valley area Skulltulas", jp: 'ゲルドの谷エリアの黄金のスタルチュラ4匹', types: ["fortress", "jabu"], subtypes: ["wallet", "child2"], child: "no" },
+  { name: "Keaton Mask", jp: 'キータンのお面', types: ["zl"], child: "yes" },
+  { name: "3 Tunics & 3 Boots", jp: '服3種類と靴3種類', types: ["tunics", "boots", "fire", "ice"], subtypes: ["mapcompass"], child: "no" },
+  { name: "All 8 Death Mountain area Skulltulas", jp: 'デスマウンテンエリアの黄金のスタルチュラ8匹', types: ["dmc"], subtypes: ["child2", "wallet"], child: "no" },
+  { name: "Map & Compass in Forest Temple", jp: '森の神殿のマップとコンパス', types: ["forest", "quiver"], subtypes: ["mapcompass", "bosskey"], child: "no" },
+  { name: "Map & Compass in Fire Temple", jp: '炎の神殿のマップとコンパス', types: ["fire"], subtypes: ["mapcompass", "bosskey"], child: "no" },
+  { name: "Forest Temple Boss Key", jp: '森の神殿のボス部屋のカギ', types: ["forest", "bosskey", "claimcheck", "quiver"], subtypes: ["mapcompass", "bosskey"], child: "no" },
+  { name: "At least 9 Magic Beans", jp: '魔法のマメ9つ以上', types: ["beans"], subtypes: ["child2", "wallet"], child: "yes" }
+];
+bingoList[15] = [
+  { name: "At least 8 songs", jp: '歌8つ以上', types: ["songs", "atrade", "zl"], subtypes: ["child2"], child: "no" },
+  { name: "Defeat Barinade", jp: 'バリネード撃破', types: ["jabu"], subtypes: ["hearts"], child: "yes" },
+  { name: "All 8 Zora's Domain area Skulltulas", jp: 'ゾーラの里エリアの黄金のスタルチュラ8匹', types: ["jabu", "ice"], subtypes: ["wallet"], child: "no" },
+  { name: "Double Magic", jp: '魔力2倍', types: ["dmc", "zl"], child: "yes" },
+  { name: "Megaton Hammer", jp: 'メガトンハンマー', types: ["fire"], subtypes: ["mapcompass", "bosskey"], child: "no" }
+];
+bingoList[16] = [
+  { name: "Blue Gauntlets", jp: '青のグローブ', types: ["spirit", "strength", "bulletbag", "atrade"], subtypes: ["wallet"], child: "no" },
+  { name: "Double Defense", jp: '防御力2倍', types: ["zl", "ganon"], child: "no" },
+  { name: "Defeat both Flare Dancers", jp: 'フレアダンサー2体撃破', types: ["fire"], subtypes: ["mapcompass", "bosskey"], child: "no" },
+  { name: "At least 3 Skulltulas in Water Temple", jp: '水の神殿の黄金のスタルチュラ3匹以上', types: ["water", "ice", "zl"], subtypes: ["wallet"], child: "no" },
+  { name: "Shadow Temple Boss Key", jp: '闇の神殿のボス部屋のカギ', types: ["shadow", "zl"], subtypes: ["hearts", "bosskey"], child: "no" },
+  { name: "Beat Jabu-Jabu's Belly", jp: 'ジャブジャブ様のお腹クリア', types: ["jabu"], subtypes: ["hearts", "child2"], child: "yes" },
+  { name: "Frog's Heart Piece", jp: 'カエルのハートのかけら(嵐の歌)', types: ["forest", "child2"], subtypes: ["hearts", "songs"], child: "no" }
+];
+bingoList[17] = [
+  { name: "Saria's Song", jp: 'サリアの歌', types: ["zl", "saria"], subtypes: ["child2", "songs"], child: "yes" },
+  { name: "Bronze Gauntlets", jp: '銅のグローブ', types: ["strength", "bulletbag", "ganon", "atrade"], subtypes: ["wallet"], child: "no" },
+  { name: "Defeat Nabooru-Knuckle", jp: 'アイアンナック(ナボール)撃破', types: ["spirit"], child: "no" },
+  { name: "3 Swords & 3 Shields", jp: '剣3種類と盾3種類', types: ["swords", "shields", "spirit"], subtypes: ["wallet"], child: "no" },
+  { name: "Get to the end of Light Trial", jp: '光の結界の最後の部屋に到達', types: ["ganon", "zl", "strength"], child: "no" },
+  { name: "8 Hearts", jp: 'ハート8つ', types: ["hearts"], child: "yes" }
+];
+bingoList[18] = [
+  { name: "Farore's Wind", jp: 'フロルの風', types: ["zl", "ice"], child: "yes" },
+  { name: "All 5 Skulltulas in Spirit Temple", jp: '魂の神殿の黄金のスタルチュラ5匹', types: ["spirit"], subtypes: ["wallet"], child: "yes" },
+  { name: "All 5 Skulltulas in Fire Temple", jp: '炎の神殿の黄金のスタルチュラ5匹', types: ["fire"], subtypes: ["wallet", "mapcompass", "bosskey"], child: "no" },
+  { name: "Defeat Volvagia", jp: 'ヴァルバジア撃破', types: ["fire"], subtypes: ["hearts", "mapcompass", "bosskey"], child: "no" },
+  { name: "At least 9 songs", jp: '歌9つ以上', types: ["songs", "atrade", "zl"], subtypes: ["child2"], child: "no" },
+  { name: "Defeat Bongo-Bongo", jp: 'ボンゴボンゴ撃破', types: ["shadow", "zl", "deku"], subtypes: ["hearts", "bosskey"], child: "no" },
+  { name: "8 different unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ8つ', types: ["fortress", "strength", "quiver"], child: "no" }
+];
+bingoList[19] = [
+  { name: "6 Maps", jp: 'マップ6つ', types: ["mapcompass", "claimcheck"], child: "yes" },
+  { name: "All 5 Lake Hylia Skulltulas", jp: 'ハイリア湖畔エリアの黄金のスタルチュラ5匹', types: ["ice", "water"], subtypes: ["child2", "wallet", "mapcompass"], child: "no" },
+  { name: "3 Shields & 3 Tunics", jp: '盾3種類と服3種類', types: ["shields", "fire", "tunics", "spirit"], child: "no" },
+  { name: "Beat the Fire Temple", jp: '炎の神殿クリア', types: ["fire", "forest"], subtypes: ["hearts", "bosskey", "mapcompass"], child: "no" },
+  { name: "Beat the Shadow Temple", jp: '闇の神殿クリア', types: ["shadow", "zl", "deku"], subtypes: ["hearts", "bosskey"], child: "no" },
+  { name: "Get to the end of Spirit Trial", jp: '魂の結界の最後の部屋に到達', types: ["ganon", "spirit", "quiver"], child: "no" }
+];
+bingoList[20] = [
+  { name: "All 4 Wasteland/ Colossus area Skulltulas", jp: '幻影の砂漠・巨大邪神像エリアの黄金のスタルチュラ4匹', types: ["spirit"], subtypes: ["child2", "wallet"], child: "no" },
+  { name: "Goron Bracelet", jp: 'ゴロンの腕輪', types: ["strength", "zl", "saria"], subtypes: ["child2"], child: "yes" },
+  { name: "Din's Fire", jp: 'ディンの炎', types: ["zl"], subtypes: ["child2"], child: "yes" },
+  { name: "Nayru's Love", jp: 'ネールの愛', types: ["spirit", "zl"], child: "yes" },
+  { name: "Free all 9 gorons in Fire Temple", jp: '炎の神殿で９人のゴロンを全員救う', types: ["fire"], subtypes: ["mapcompass", "bosskey"], child: "no" }
+];
+bingoList[21] = [
+  { name: "Light Arrows", jp: '光の矢', types: ["lightarrow", "atrade", "zl"], child: "no" },
+  { name: "6 Compasses", jp: 'コンパス6つ', types: ["mapcompass"], child: "yes" },
+  { name: "All 4 Market area Skulltulas", jp: '城下町エリアの黄金のスタルチュラ4匹', types: ["forest", "child2"], subtypes: ["wallet"], subtypes: ["hearts"], child: "no" },
+  { name: "Spooky Mask", jp: 'こわそなお面', types: ["zl", "fortress", "saria", "beans"], child: "yes" },
+  { name: "Defeat Meg (purple Poe)", jp: 'メグ撃破(紫のポウ)', types: ["forest", "quiver"], subtypes: ["mapcompass", "bosskey"], child: "no" }
+];
+bingoList[22] = [
+  { name: "Both heart pieces in Lost Woods", jp: '迷いの森のハートのかけら２つ', types: ["zl"], subtypes: ["hearts", "child2", "songs"], child: "yes" },
+  { name: "3 Shields & 3 Boots", jp: '盾3種類と靴3種類', types: ["shields", "boots", "spirit", "ice"], subtypes: ["mapcompass"], child: "yes" },
+  { name: "Get to the end of Water Trial", jp: '水の結界の最後の部屋に到達', types: ["ganon", "fire", "lightarrow"], subtypes: ["mapcompass", "bosskey"], child: "no" },
+  { name: "Map & Compass in Spirit Temple", jp: '魂の神殿のマップとコンパス', types: ["spirit", "zl"], subtypes: ["mapcompass"], child: "yes" },
+  { name: "Spirit Temple Boss Key", jp: '魂の神殿のボス部屋のカギ', types: ["spirit", "lightarrow", "zl"], subtypes: ["bosskey"], child: "no" }
+];
+bingoList[23] = [
+  { name: "9 Hearts", jp: 'ハート9つ', types: ["hearts"], child: "yes" },
+  { name: "7 Maps", jp: 'マップ7つ', types: ["mapcompass", "claimcheck"], child: "yes" },
+  { name: "Defeat Twinrova", jp: 'ツインローバ撃破', types: ["spirit"], subtypes: ["hearts"], child: "no" },
+  { name: "Quiver (50)", jp: '矢立て(50)', types: ["quiver", "fortress", "beans"], child: "no" }
+];
+bingoList[24] = [
+  { name: "Beat the Spirit Temple", jp: '魂の神殿クリア', types: ["spirit"], subtypes: ["hearts"], child: "no" },
+  { name: "All 5 Skulltulas in Shadow Temple", jp: '闇の神殿の黄金のスタルチュラ5匹', types: ["shadow", "zl"], subtypes: ["wallet", "bosskey"], child: "no" },
+  { name: "7 Compasses", jp: 'コンパス7つ', types: ["mapcompass"], child: "no" },
+  { name: "Get to the end of Shadow Trial", jp: '闇の結界の最後の部屋に到達', types: ["ganon", "fire"], subtypes: ["mapcompass", "bosskey"], child: "no" }
+];
+bingoList[25] = [
+  { name: "All 5 Skulltulas in Water Temple", jp: '水の神殿の黄金のスタルチュラ5匹', types: ["water", "zl"], child: "no" },
+  { name: "Two Fairy Spells", jp: '魔法のアイテム２つ', types: ["zl", "spirit"], subtypes: ["child2"], child: "yes" },
+  { name: "Green Gauntlets", jp: '緑のグローブ', types: ["strength", "bulletbag", "zl", "atrade", "saria"], subtypes: ["wallet"], child: "no" },
+  { name: "Get to the end of the Forest Trial", jp: '森の結界の最後の部屋に到達', types: ["ganon", "zl", "firearrow"], child: "yes" }
+];

--- a/versions/v8/v8.4/generator.js
+++ b/versions/v8/v8.4/generator.js
@@ -1,0 +1,314 @@
+//NOTICE: As of version 6, this script will only generate cards correctly for Ocarina of Time bingo
+//and as shuch should be saved alongside the regular bingo script.
+ootBingoGenerator = function(bingoList, opts) {
+	if(!opts) opts = {};
+	var LANG = opts.lang || 'name';
+	var SEED = opts.seed || Math.ceil(999999 * Math.random()).toString();
+	Math.seedrandom(SEED);
+	var MODE = opts.mode || 'normal';
+  
+	//giuocob 16-8-12: lineCheckList[] has been replaced to allow for removal of all-child rows
+	//Note: the rowElements relation is simply the inverse of the rowCheckList relation
+	var rowElements = {};
+	rowElements["row1"] = [1,2,3,4,5];
+	rowElements["row2"] = [6,7,8,9,10];
+	rowElements["row3"] = [11,12,13,14,15];
+	rowElements["row4"] = [16,17,18,19,20];
+	rowElements["row5"] = [21,22,23,24,25];
+	rowElements["col1"] = [1,6,11,16,21];
+	rowElements["col2"] = [2,7,12,17,22];
+	rowElements["col3"] = [3,8,13,18,23];
+	rowElements["col4"] = [4,9,14,19,24];
+	rowElements["col5"] = [5,10,15,20,25];
+	rowElements["tlbr"] = [1,7,13,19,25];
+	rowElements["bltr"] = [5,9,13,17,21];
+
+	//Given an object that maps keys to flat arrays, invert said object
+	function invertObject(obj) {
+		var ret = {};
+		Object.keys(obj).forEach(function(key) {
+			obj[key].forEach(function(item) {
+				if(!ret[item]) ret[item] = [];
+				ret[item].push(key);
+			});
+		});
+		return ret;
+	}
+
+	rowCheckList = invertObject(rowElements);
+
+
+
+
+	//Main entry point
+	function makeCard() {
+		var bingoBoard = []; //the board itself stored as an array first
+		for (var i=1;i<=25;i++) {
+			if(MODE == "short")
+			{
+		        bingoBoard[i] = {difficulty: difficulty(i), child: "yes"};
+		    }
+		    else
+		    {
+				bingoBoard[i] = {difficulty: difficulty(i), child: "no"};
+			}
+		}                                          // in order 1-25
+	  
+	  
+	    //giuocob 19-2-13: bingoBoard is no longer populated left to right:
+	    //It is now populated mostly randomly, with high difficult goals and
+	    //goals on the diagonals out in front
+	    var populationOrder = [];
+	    populationOrder[1] = 13;   //Populate center first
+	    var diagonals = [1,7,19,25,5,9,17,21];
+	    shuffle(diagonals);
+	    populationOrder = populationOrder.concat(diagonals);   //Next populate diagonals
+	    var nondiagonals = [2,3,4,6,8,10,11,12,14,15,16,18,20,22,23,24];
+	    shuffle(nondiagonals);
+	    populationOrder = populationOrder.concat(nondiagonals);   //Finally add the rest of the squares
+	    //Lastly, find location of difficulty 23,24,25 elements and put them out front
+	    for(var k=23;k<=25;k++)
+	    {
+			var currentSquare = getDifficultyIndex(k);
+			if(currentSquare == 0) continue;
+			for(var i=1;i<25;i++)
+			{
+				if(populationOrder[i] == currentSquare)
+				{
+					populationOrder.splice(i,1);
+					break;
+				}
+			}
+			populationOrder.splice(1,0,currentSquare);
+		}
+
+	    
+	  
+	    //Populate the bingo board in the array
+	    //giuocob 16-8-12: changed this section to:
+	    //1. Support uniform goal selection by shuffling arrays before checking goals
+	    //2. Remove all child rows by checking child tag
+	    //3. If no goal is suitable, instead of choosing goal with lowest synergy, now next difficulty up is checked
+	    for(var i=1;i<=25;i++)
+	    {
+			var sq = populationOrder[i];
+			var getDifficulty = bingoBoard[sq].difficulty;
+			var goalArray = getShuffledGoals(getDifficulty);
+			var j=0, synergy=0, spill = 0, currentObj=null, minSynObj=null;
+			do
+			{
+				currentObj = goalArray[j];
+				synergy = checkLine(sq,currentObj);
+				if(minSynObj == null || synergy < minSynObj.synergy)
+				{
+					minSynObj = {synergy: synergy, value: currentObj};
+				}
+				j++;
+				if(j >= goalArray.length)
+				{
+					getDifficulty++;
+					spill++;
+					if(getDifficulty > 25) {
+						return false;  //HIT THE PANIC BUTTON, RUN FOR THE HILLS
+					} else if(spill >=3) {
+						return false;  //THIS BINGO CARD IS IN UNACCEPTABLE CONDITION
+					} else {
+					    goalArray = getShuffledGoals(getDifficulty);
+					    j = 0;
+					}
+				}
+			} while(synergy != 0);   //Perhaps increase to 1 if difficulty increases happen too often
+			
+	    
+		    bingoBoard[sq].types = minSynObj.value.types;
+		    bingoBoard[sq].subtypes = minSynObj.value.subtypes;
+		    bingoBoard[sq].name = minSynObj.value[LANG] || minSynObj.value.name;
+		    bingoBoard[sq].child = minSynObj.value.child;
+		    bingoBoard[sq].synergy = minSynObj.synergy;
+	    }
+
+	    return bingoBoard;
+
+
+
+
+    	function mirror(i) {
+			if      (i == 0) { i = 4; }
+			else if (i == 1) { i = 3; }
+			else if (i == 3) { i = 1; }
+			else if (i == 4) { i = 0; }
+			return i;
+		}
+
+		function difficulty(i) {
+			// To create the magic square we need 2 random orderings of the numbers 0, 1, 2, 3, 4.
+			// The following creates those orderings and calls them Table5 and Table1
+			
+			var Num3 = SEED%1000;	// Table5 will use the ones, tens, and hundreds digits.
+
+			var Rem8 = Num3%8;
+			var Rem4 = Math.floor(Rem8/2);
+			var Rem2 = Rem8%2;
+			var Rem5 = Num3%5;
+			var Rem3 = Num3%3;	// Note that Rem2, Rem3, Rem4, and Rem5 are mathematically independent.
+			var RemT = Math.floor(Num3/120);	// This is between 0 and 8		
+
+			// The idea is to begin with an array containing a single number, 0.
+			// Each number 1 through 4 is added in a random spot in the array's current size.
+			// The result - the numbers 0 to 4 are in the array in a random (and uniform) order.
+			var Table5 = [0];
+			Table5.splice(Rem2, 0, 1);
+			Table5.splice(Rem3, 0, 2);
+			Table5.splice(Rem4, 0, 3);
+			Table5.splice(Rem5, 0, 4);
+
+			Num3 = Math.floor(SEED/1000);	// Table1 will use the next 3 digits.
+			Num3 = Num3%1000;
+
+			Rem8 = Num3%8;
+			Rem4 = Math.floor(Rem8/2);
+			Rem2 = Rem8%2;
+			Rem5 = Num3%5;
+			Rem3 = Num3%3;
+			RemT = RemT * 8 + Math.floor(Num3/120);	 // This is between 0 and 64.
+
+			var Table1 = [0];
+			Table1.splice(Rem2, 0, 1);
+			Table1.splice(Rem3, 0, 2);
+			Table1.splice(Rem4, 0, 3);
+			Table1.splice(Rem5, 0, 4);
+
+			i--;
+			RemT = RemT%5;		//  Between 0 and 4, fairly uniformly.
+			x = (i+RemT)%5;		//  RemT is horizontal shift to put any diagonal on the main diagonal.
+			y = Math.floor(i/5);
+
+			// The Tables are set into a single magic square template
+			// Some are the same up to some rotation, reflection, or row permutation.
+			// However, all genuinely different magic squares can arise in this fashion.
+			var e5 = Table5[(x + 3*y)%5];
+			var e1 = Table1[(3*x + y)%5];
+
+			// Table5 controls the 5* part and Table1 controls the 1* part.
+			value = 5*e5 + e1;
+
+			if (MODE == "short") { value = Math.floor(value/2); } // if short mode, limit difficulty
+		    	else if (MODE == "long") { value = Math.floor((value + 25) / 2); }
+		    	value++;
+			return value;
+		}
+
+		//Uniformly shuffles an array (note: the original array will be changed)
+		function shuffle(toShuffle)
+		{
+			for(var i=0;i<toShuffle.length;i++)
+			{
+				var randElement = Math.floor(Math.random()*(i+1));
+				var temp = toShuffle[i];
+				toShuffle[i] = toShuffle[randElement];
+				toShuffle[randElement] = temp;
+			}
+		}
+
+		//Get a uniformly shuffled array of all the goals of a given difficulty tier
+		function getShuffledGoals(difficulty)
+		{
+			var newArray = bingoList[difficulty].slice();
+			shuffle(newArray);
+			return newArray;
+		}
+
+		//Given a difficulty as an argument, find the square that contains that difficulty
+		function getDifficultyIndex(difficulty)
+		{
+			for(var i=1;i<=25;i++)
+			{
+				if(bingoBoard[i].difficulty == difficulty)
+				{
+					return i;
+				}
+			}
+			return 0;
+		}
+		  
+
+
+		function checkLine(i, testsquare)
+		{
+			var typesA = testsquare.types || [];
+			var subtypesA = testsquare.subtypes || [];
+			var synergy = 0;
+			var rows = rowCheckList[i], elements = [];
+			var childCount = 0;
+			for(var k=0;k<rows.length;k++)
+			{
+				elements = rowElements[rows[k]];
+				childCount = 0;
+				for(var m=0;m<elements.length;m++)
+				{
+					var testsquare2 = bingoBoard[elements[m]];
+					var typesB = testsquare2.types || [];
+					var subtypesB = testsquare2.subtypes || [];
+					if(typeof typesB != 'undefined')
+					{
+						function matchArrays(arr1, arr2) {
+							for(var n=0;n<arr1.length;n++) {
+								for(var p=0;p<arr2.length;p++) {
+									if(arr1[n] == arr2[p]) synergy++;
+								}
+							}
+						}
+
+						matchArrays(typesA, typesB);
+						matchArrays(typesA, subtypesB);
+						matchArrays(subtypesA, typesB);
+					}
+					if(bingoBoard[elements[m]].child == "yes")
+					{
+						childCount++;
+					}
+				}
+				//Remove child-only rows, remove adult goals from short
+				if(MODE == "short")
+				{
+					if(testsquare.child == "no")
+					{
+						childCount--;
+					}
+					if(childCount < 5)
+					{
+						synergy += 3;
+					}
+				}
+				else
+				{
+					if(testsquare.child == "yes")
+					{
+						childCount++;
+					}
+					if(childCount > 4)
+					{
+						synergy += 3;
+					}
+				}
+			}
+			return synergy;
+		}
+	}
+
+
+	//Loop over cards until one is accepted.
+	var card;
+	var iterations = 0;
+	while(true) {
+		iterations++;
+		card = makeCard();
+		if(card === false) {
+			continue;
+		} else {
+			break;
+		}
+	}
+  
+  	return card;
+}

--- a/versions/v8/v8.4/goal-list.js
+++ b/versions/v8/v8.4/goal-list.js
@@ -1,0 +1,213 @@
+var bingoList = [];
+bingoList["info"] = {
+version: "v8.4"
+};
+bingoList[1] = [
+	{ name: "Bottled Fairy", jp: 'ビン(妖精)', types: ["bottle"], child: "yes" },
+	{ name: "Bullet Bag (50)", jp: 'デクのタネ袋(50)', types: ["bulletbag"], child: "yes" },
+	{ name: "Bomb Bag (30)", jp: 'ボム袋(30)', types: ["bombbag"], child: "yes" },
+	{ name: "Lens of Truth", jp: 'まことのメガネ', types: ["botw"], child: "yes" } ,
+	{ name: "Defeat a Skull Kid", jp: 'スタルキッド撃破', types: ["skullkid"], child: "no" },
+	{ name: "At least 30 Deku Nuts", jp: 'デクの実30個以上', types: ["nuts"], child: "yes" }
+];
+bingoList[2] = [
+	{ name: "Map & Compass in Dodongo's Cavern", jp: 'ドドンゴの洞窟のマップとコンパス', types: ["dc"], subtypes: ["mapcompass"], child: "yes" },
+	{ name: "Map & Compass in Deku Tree", jp: 'デクの樹様の中のマップとコンパス', types: ["deku"], subtypes: ["mapcompass"], child: "yes" },
+	{ name: "Map & Compass in Bottom of the Well", jp: '井戸の底のマップとコンパス', types: ["botw"], subtypes: ["mapcompass"], child: "yes" },
+	{ name: "Giant's Knife", jp: '巨人のナイフ', types: ["swords"], subtypes: ["wallet"], child: "no" },
+	{ name: "Minuet of Forest", jp: '森のメヌエット', types: ["forest"], subtypes: ["songs"], child: "no" },
+	{ name: "Goron Tunic", jp: 'ゴロンの服', types: ["tunics", "dmc", "fire"], child: "no" },
+	{ name: "Zora Tunic", jp: 'ゾーラの服', types: ["tunics", "ice"], child: "no" }
+];
+bingoList[3] = [
+	{ name: "Both heart pieces in Death Mountain Crater", jp: 'デスマウンテン火口のハートのかけら２つ', types: ["dmc", "fire"], subtypes: ["hearts"], child: "yes" },
+	{ name: "Fairy Slingshot", jp: '妖精のパチンコ', types: ["bulletbag", "deku"], child: "yes" },
+	{ name: "At least 3 songs", jp: '歌3つ以上', types: ["songs", "zl"], child: "yes" },
+	{ name: "Quiver (40)", jp: '矢立て(40)', types: ["atrade", "forest", "quiver"], child: "no" },
+	{ name: "Defeat all Lizalfos in Dodongo's Cavern", jp: 'ドドンゴの洞窟のリザルフォス全て撃破', types: ["dc"], child: "yes" },
+	{ name: "Bolero of Fire", jp: '炎のボレロ', types: ["dmc", "fire"], subtypes: ["songs"], child: "no" }
+];
+bingoList[4] = [
+	{ name: "30 Deku Sticks", jp: 'デクの棒30本', types: ["atrade"], child: "yes" },
+	{ name: "Defeat King Dodongo", jp: 'キングドドンゴ撃破', types: ["dc", "kd"], subtypes: ["hearts"], child: "yes" },
+	{ name: "Fire Temple Boss Key", jp: '炎の神殿のボス部屋のカギ', types: ["fire"], subtypes: ["bosskey"], child: "no"},
+	{ name: "Ruto's Letter", jp: 'ルトの手紙', types: ["bottle"], child: "yes" },
+	{ name: "Ice Arrows", jp: '氷の矢', types: ["fortress", "quiver"], subtypes: ["kd"], child: "yes" },
+	{ name: "Map & Compass in Shadow Temple", jp: '闇の神殿のマップとコンパス', types: ["shadow"], subtypes: ["mapcompass"], child: "yes" }
+];
+bingoList[5] = [
+	{ name: "Bullet Bag (40)", jp: 'デクのタネ袋(40)', types: ["bulletbag", "deku"], child: "yes" },
+	{ name: "Blue Fire", jp: '青い炎', types: ["ice", "bottle", "ganon"], child: "yes" },
+	{ name: "Defeat Queen Gohma", jp: 'ゴーマ撃破', types: ["deku", "ganon"], subtypes: ["hearts"], child: "yes" },
+	{ name: "All 3 Kokiri Forest area Skulltulas", jp: 'コキリの森エリアの黄金のスタルチュラ３匹', types: ["forest"], subtypes: ["wallet"], child: "no" },
+	{ name: "Ice Cavern Heart Piece", jp: '氷の洞窟のハートのかけら', types: ["ice"], subtypes: ["hearts", "mapcompass"], child: "yes" },
+	{ name: "3 Tunics", jp: '服3種類', types: ["tunics", "ice", "fire"], child: "no" },
+	{ name: "Water Temple Boss Key", jp: '水の神殿のボス部屋のカギ', types: ["water", "fortress"], subtypes: ["bosskey"], child: "no" }
+];
+bingoList[6] = [
+	{ name: "Beat Dodongo's Cavern", jp: 'ドドンゴの洞窟クリア', types: ["dc", "fortress", "kd"], child: "yes" },
+	{ name: "Map & Compass in Ice Cavern", jp: '氷の洞窟のマップとコンパス', types: ["ice"], subtypes: ["mapcompass"], child: "yes" },
+	{ name: "Defeat a White Wolfos", jp: 'ホワイトウルフォス撃破', types: ["ice", "fortress"], subtypes: ["mapcompass"], child: "yes" },
+	{ name: "Ganon's Castle Boss Key", jp: 'ガノン城のボス部屋のカギ', types: ["ganon", "deku"], subtypes: ["bosskey"], child: "yes" },
+	{ name: "All 3 Skulltulas in Bottom of the Well", jp: '井戸の底の黄金のスタルチュラ3匹', types: ["botw"], subtypes: ["wallet"], child: "yes" },
+	{ name: "Cow in House", jp: '牛(リンクの家)', types: ["cow"], child: "no" },
+	{ name: "Beat the Deku Tree", jp: 'デクの樹様の中クリア', types: ["deku", "ganon"], child: "yes" },
+	{ name: "3 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ3つ', types: ["fortress"], child: "yes" },
+	{ name: "All 3 Skulltulas in Ice Cavern", jp: '氷の洞窟の黄金のスタルチュラ3匹', types: ["ice"], subtypes: ["wallet", "mapcompass"], child: "yes" }
+];
+bingoList[7] = [
+	{ name: "Milk", jp: 'ロンロン牛乳', types: ["lonlon", "bottle"], child: "yes" },
+	{ name: "4 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ4つ', types: ["fortress"], child: "yes" },
+	{ name: "All 4 Lost Woods area Skulltulas", jp: '迷いの森エリアの黄金のスタルチュラ4匹', types: ["forest"], subtypes: ["wallet"], child: "no" },
+	{ name: "Fill all 4 Bottle Slots", jp: '4つの空きビンスロットを全て埋める', types: ["bottle"], child: "yes" },
+	{ name: "Blue Potion", jp: '青いクスリ', types: ["atrade", "zl"], child: "no" },
+	{ name: "At least 4 songs", jp: '歌4つ以上', types: ["songs", "atrade", "zl"], subtypes: ["child2"], child: "yes" },
+	{ name: "Giant's Wallet", jp: '巨人のサイフ', types: ["wallet"], child: "yes" }
+];
+bingoList[8] = [
+	{ name: "Plant bean in Death Mountain Crater", jp: 'デスマウンテン火口の土にマメを植える', types: ["dmc", "beans"], subtypes: ["child2"], child: "yes" },
+	{ name: "Both Gerudo's Fortress area Skulltulas", jp: 'ゲルドの砦の黄金のスタルチュラ2匹', types: ["fortress"], subtypes: ["wallet"], child: "no" },
+	{ name: "Epona's Song", jp: 'エポナの歌', types: ["lonlon"], subtypes: ["songs"], child: "yes" },
+	{ name: "Iron Boots", jp: 'ヘビーブーツ', types: ["ice", "boots", "mapcompass"], child: "yes" },
+	{ name: "5 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ5つ', types: ["fortress"], child: "yes" },
+	{ name: "6 Hearts", jp: 'ハート6つ', types: ["hearts"], child: "yes" },
+	{ name: "Defeat Phantom Ganon", jp: 'ファントムガノン撃破', types: ["forest", "pg"], subtypes: ["hearts"], child: "yes" },
+	{ name: "Map & Compass in Water Temple", jp: '水の神殿のマップとコンパス', types: ["water"], subtypes: ["mapcompass"], child: "no" }
+];
+bingoList[9] = [
+	{ name: "3 Swords & 3 Tunics", jp: '剣3種類と服3種類', types: ["swords", "tunics", "ice", "fire"], subtypes: ["wallet"], child: "no" },
+	{ name: "3 Boots", jp: '靴3種類', types: ["boots", "ice", "mapcompass"], child: "yes" },
+	{ name: "All 5 Skulltulas in Dodongo's Cavern", jp: 'ドドンゴの洞窟の黄金のスタルチュラ5匹', types: ["dc"], subtypes: ["wallet"], child: "yes" },
+	{ name: "Defeat Morpha", jp: 'モーファ撃破', types: ["water"], subtypes: ["hearts"], child: "no" },
+	{ name: "Beat the Forest Temple", jp: '森の神殿クリア', types: ["forest", "pg"], subtypes: ["hearts"], child: "yes" },
+	{ name: "500 Rupees", jp: '500ルピー', types: ["wallet"], child: "yes" }
+];
+bingoList[10] = [
+	{ name: "At least 7 Magic Beans", jp: '魔法のマメ7つ以上', types: ["beans"], subtypes: ["child2", "wallet"], child: "yes" },
+	{ name: "Defeat Big Octo", jp: '大オクタ撃破', types: ["jabu", "ice"], child: "yes" },
+	{ name: "37th heart piece (Child Fortress)", jp: '37番目のハートのかけら(子供のゲルドの砦)', types: ["fortress"], subtypes: ["hearts", "kd"], child: "yes" },
+	{ name: "Beat the Water Temple", jp: '水の神殿クリア', types: ["water"], subtypes: ["hearts"], child: "no" },
+	{ name: "Forest Medallion", jp: '森のメダル', types: ["forest", "lightarrow", "atrade", "zl", "pg"], subtypes: ["hearts"], child: "yes" },
+	{ name: "6 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ6つ', types: ["fortress"], child: "yes" },
+	{ name: "Requiem of Spirit", jp: '魂のレクイエム', types: ["spirit"], subtypes: ["songs"], child: "yes" },
+	{ name: "At least 6 songs", jp: '歌6つ以上', types: ["songs", "atrade", "zl"], subtypes: ["child2"], child: "no" }
+];
+bingoList[11] = [										   
+	{ name: "At least 4 Skulltulas in Shadow Temple", jp: '闇の神殿の黄金のスタルチュラ4匹以上', types: ["shadow"], subtypes: ["wallet"], child: "no" },
+	{ name: "All 8 Kakariko area Skulltulas", jp: 'カカリコ村エリアの黄金のスタルチュラ8匹', types: ["botw"], subtypes: ["wallet"], child: "no" },
+	{ name: "Mirror Shield", jp: 'ミラーシールド', types: ["shields", "spirit"], child: "yes" },
+	{ name: "All 5 Skulltulas in Forest Temple", jp: '森の神殿の黄金のスタルチュラ5匹', types: ["forest"], subtypes: ["wallet"], child: "no" },
+	{ name: "All 4 Skulltulas in Deku Tree", jp: 'デクの樹様の中の黄金のスタルチュラ4匹', types: ["deku"], subtypes: ["wallet"], child: "yes" },
+	{ name: "Water Medallion", jp: '水のメダル', types: ["water", "lightarrow", "atrade", "zl"], subtypes: ["hearts"], child: "no" },
+	{ name: "Gerudo's Card", jp: 'ゲルドの会員証', types: ["fortress"], child: "yes" },
+	{ name: "Defeat Amy (Green Poe)", jp: 'エイミー撃破(緑のポウ)ｴ', types: ["forest", "fortress", "quiver"], subtypes: ["mapcompass", "bosskey"], child: "no" }
+];
+bingoList[12] = [
+	{ name: "Stone of Agony", jp: 'もだえ石', types: ["wallet"], child: "yes" },
+	{ name: "Get to the end of Fire Trial", jp: '炎の結界の最後の部屋に到達', types: ["ganon", "strength", "fire"], subtypes: ["bosskey"], child: "no" },
+	{ name: "Golden Gauntlets", jp: '金のグローブ', types: ["strength", "ganon", "deku"], child: "yes" },
+	{ name: "Get Bombchu chest in Spirit Temple", jp: '魂の神殿のボムチュウ取得', types: ["spirit"], child: "yes" },
+	{ name: "All 4 Skulltulas in Jabu-Jabu", jp: 'ジャブジャブ様のお腹の黄金のスタルチュラ4匹', types: ["jabu", "ice"], subtypes: ["hearts", "wallet"], child: "yes" },
+	{ name: "Fairy Bow", jp: '妖精の弓', types: ["forest", "quiver"], subtypes: ["mapcompass", "bosskey"], child: "no" },
+	{ name: "Defeat Dark Link", jp: 'ダークリンク撃破', types: ["water", "ice"], child: "no" },
+	{ name: "Fire Arrow", jp: '炎の矢', types: ["water", "fortress", "firearrow", "quiver"], child: "no" }
+];
+bingoList[13] = [
+	{ name: "7 Hearts", jp: 'ハート7つ', types: ["hearts"], child: "yes" },
+	{ name: "Map & Compass in Jabu-Jabu", jp: 'ジャブジャブ様のお腹のマップとコンパス', types: ["jabu"], subtypes: ["mapcompass"], child: "yes" },
+	{ name: "Win Bombchu Bowling Prize", jp: 'ボムチュウボウリングのハートのかけら', types: ["dc", "kd"], subtypes: ["hearts", "child2"], child: "yes" },
+	{ name: "Silver Gauntlets", jp: '銀のグローブ', types: ["strength", "spirit"], child: "yes" },
+	{ name: "Longshot", jp: 'ロングフック', types: ["water", "ice"], child: "no" },
+	{ name: "3 Swords & 3 Boots", jp: '剣3種類と靴3種類', types: ["swords", "boots", "ice"], subtypes: ["wallet", "mapcompass"], child: "no" }
+];
+bingoList[14] = [
+	{ name: "Both Hyrule Field area Skulltulas", jp: 'ハイラル平原エリアの黄金のスタルチュラ2匹', types: ["zl", "water"], subtypes: ["wallet"], child: "yes" },
+	{ name: "All 4 Lon-Lon Ranch area Skulltulas", jp: 'ロンロン牧場エリアの黄金のスタルチュラ4匹', types: ["jabu", "lonlon"], subtypes: ["wallet"], child: "yes" },
+	{ name: "Double Magic", jp: '魔力2倍', types: ["dmc", "zl"], child: "yes" },
+	{ name: "At least 8 songs", jp: '歌8つ以上', types: ["songs", "atrade", "zl"], subtypes: ["child2"], child: "no" },
+	{ name: "Bronze Gauntlets", jp: '銅のグローブ', types: ["strength", "bulletbag", "ganon", "atrade"], subtypes: ["wallet"], child: "no" },
+	{ name: "Keaton Mask", jp: 'キータンのお面', types: ["zl"], child: "yes" },
+	{ name: "3 Tunics & 3 Boots", jp: '服3種類と靴3種類', types: ["tunics", "boots", "fire", "ice"], subtypes: ["mapcompass"], child: "no" },
+	{ name: "Forest Temple Boss Key", jp: '森の神殿のボス部屋のカギ', types: ["forest", "claimcheck", "quiver"], subtypes: ["mapcompass", "bosskey"], child: "no" }
+];
+bingoList[15] = [
+	{ name: "Map & Compass in Forest Temple", jp: '森の神殿のマップとコンパス', types: ["forest", "quiver"], subtypes: ["mapcompass", "bosskey"], child: "no" },
+	{ name: "Map & Compass in Fire Temple", jp: '炎の神殿のマップとコンパス', types: ["fire"], subtypes: ["mapcompass", "bosskey"], child: "no" },
+	{ name: "All 4 Gerudo Valley area Skulltulas", jp: 'ゲルドの谷エリアの黄金のスタルチュラ4匹', types: ["fortress"], subtypes: ["wallet", "child2"], child: "no" },
+	{ name: "All 8 Death Mountain area Skulltulas", jp: 'デスマウンテンエリアの黄金のスタルチュラ8匹', types: ["dmc"], subtypes: ["child2", "wallet"], child: "no" },
+	{ name: "At least 9 Magic Beans", jp: '魔法のマメ9つ以上', types: ["beans"], subtypes: ["child2", "wallet"], child: "yes" },
+	{ name: "Blue Gauntlets", jp: '青のグローブ', types: ["spirit", "strength", "bulletbag", "atrade"], subtypes: ["wallet"], child: "no" }
+];
+bingoList[16] = [
+	{ name: "Megaton Hammer", jp: 'メガトンハンマー', types: ["fire"], subtypes: ["mapcompass", "bosskey"], child: "no" },
+	{ name: "6 Maps", jp: 'マップ6つ', types: ["mapcompass", "claimcheck"], child: "yes" },
+	{ name: "All 8 Zora's Domain area Skulltulas", jp: 'ゾーラの里エリアの黄金のスタルチュラ8匹', types: ["jabu", "ice"], subtypes: ["wallet"], child: "no" },
+	{ name: "Defeat Barinade", jp: 'バリネード撃破', types: ["jabu"], subtypes: ["hearts"], child: "yes" },
+	{ name: "Double Defense", jp: '防御力2倍', types: ["zl", "ganon"], child: "no" },
+	{ name: "At least 3 Skulltulas in Water Temple", jp: '水の神殿の黄金のスタルチュラ3匹以上', types: ["water", "ice", "zl"], subtypes: ["wallet"], child: "no"}
+];
+bingoList[17] = [
+	{ name: "Frog's Heart Piece", jp: 'カエルのハートのかけら(嵐の歌)', types: ["forest", "child2", "pg"], subtypes: ["hearts", "songs"], child: "no" },
+	{ name: "Shadow Temple Boss Key", jp: '闇の神殿のボス部屋のカギ', types: ["shadow", "zl"], subtypes: ["hearts", "bosskey"], child: "no"},
+	{ name: "Defeat both Flare Dancers", jp: 'フレアダンサー2体撃破', types: ["fire"], subtypes: ["mapcompass", "bosskey"], child: "no" },
+	{ name: "Beat Jabu-Jabu's Belly", jp: 'ジャブジャブ様のお腹クリア', types: ["jabu"], subtypes: ["hearts", "child2"], child: "yes" },
+	{ name: "All 5 Skulltulas in Spirit Temple", jp: '魂の神殿の黄金のスタルチュラ5匹', types: ["spirit"], subtypes: ["wallet"], child: "yes" },
+	{ name: "3 Swords & 3 Shields", jp: '剣3種類と盾3種類', types: ["swords", "shields", "spirit"], subtypes: ["wallet"], child: "no" },
+	{ name: "Get to the end of Light Trial", jp: '光の結界の最後の部屋に到達', types: ["ganon", "zl", "strength"] , child: "no"},
+	{ name: "8 different unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ8つ', types: ["fortress", "strength", "quiver"], child: "no" }
+];
+bingoList[18] = [
+	{ name: "Defeat Nabooru-Knuckle", jp: 'アイアンナック(ナボール)撃破', types: ["spirit"], child: "no" },
+	{ name: "Saria's Song", jp: 'サリアの歌', types: ["zl", "saria"], subtypes: ["child2", "songs"], child: "yes" },
+	{ name: "Farore's Wind", jp: 'フロルの風', types: ["zl", "ice"], child: "yes" },
+	{ name: "All 5 Skulltulas in Fire Temple", jp: '炎の神殿の黄金のスタルチュラ5匹', types: ["fire"], subtypes: ["wallet", "mapcompass", "bosskey"], child: "no" },
+	{ name: "Defeat Volvagia", jp: 'ヴァルバジア撃破', types: ["fire"], subtypes: ["hearts", "mapcompass", "bosskey", "pg"], child: "no" },
+	{ name: "At least 9 songs", jp: '歌9つ以上', types: ["songs", "atrade", "zl"], subtypes: ["child2"], child: "no" }
+];
+bingoList[19] = [
+	{ name: "Defeat Bongo-Bongo", jp: 'ボンゴボンゴ撃破', types: ["shadow", "zl", "deku"], subtypes: ["hearts", "bosskey"], child: "no" },
+	{ name: "8 Hearts", jp: 'ハート8つ', types: ["hearts"], child: "yes" },
+	{ name: "6 Compasses", jp: 'コンパス6つ', types: ["mapcompass"], child: "yes" },
+	{ name: "3 Shields & 3 Tunics", jp: '盾3種類と服3種類', types: ["shields", "fire", "tunics", "spirit"], child: "no" },
+	{ name: "Beat the Fire Temple", jp: '炎の神殿クリア', types: ["fire", "forest"], subtypes: ["hearts", "bosskey", "mapcompass", "pg"], child: "no" },
+];
+bingoList[20] = [
+	{ name: "Light Arrows", jp: '光の矢', types: ["lightarrow", "atrade", "zl"], child: "no" },
+	{ name: "Beat the Shadow Temple", jp: '闇の神殿クリア', types: ["shadow", "zl", "deku"], subtypes: ["hearts", "bosskey"], child: "no" },
+	{ name: "Defeat Meg (purple Poe)", jp: 'メグ撃破(紫のポウ)', types: ["forest", "quiver"], subtypes: ["mapcompass", "bosskey"], child: "no" },
+	{ name: "All 4 Wasteland/ Colossus area Skulltulas", jp: '幻影の砂漠・巨大邪神像エリアの黄金のスタルチュラ4匹', types: ["spirit"], subtypes: ["child2", "wallet", "kd"], child: "no" },
+	{ name: "Goron Bracelet", jp: 'ゴロンの腕輪', types: ["strength", "zl", "saria"], subtypes: ["child2"], child: "yes" },
+	{ name: "Nayru's Love", jp: 'ネールの愛', types: ["spirit", "zl"], child: "yes" },
+	{ name: "Free all 9 gorons in Fire Temple", jp: '炎の神殿で９人のゴロンを全員救う', types: ["fire"], subtypes: ["mapcompass", "bosskey"], child: "no"}
+];
+bingoList[21] = [
+	{ name: "All 5 Lake Hylia Skulltulas", jp: 'ハイリア湖畔エリアの黄金のスタルチュラ5匹', types: ["ice", "water"], subtypes: ["child2", "wallet", "mapcompass"], child: "no" },
+	{ name: "Din's Fire", jp: 'ディンの炎', types: ["zl"], subtypes: ["child2"], child: "yes" },
+	{ name: "Get to the end of Spirit Trial", jp: '魂の結界の最後の部屋に到達', types: ["ganon", "spirit", "quiver"], child: "no" },
+	{ name: "All 4 Market area Skulltulas", jp: '城下町エリアの黄金のスタルチュラ4匹', types: ["forest", "child2", "pg"], subtypes: ["hearts", "wallet"], child: "no" },
+	{ name: "Spooky Mask", jp: 'こわそなお面', types: ["zl", "fortress", "saria", "beans"], child: "yes" }
+];
+bingoList[22] = [
+	{ name: "Spirit Temple Boss Key", jp: '魂の神殿のボス部屋のカギ', types: ["spirit", "lightarrow", "zl"], subtypes: ["bosskey"], child: "no" },
+	{ name: "Quiver (50)", jp: '矢立て(50)', types: ["quiver", "fortress", "beans"], child: "no" },
+	{ name: "3 Shields & 3 Boots", jp: '盾3種類と靴3種類', types: ["shields", "boots", "spirit", "ice"], subtypes: ["mapcompass"], child: "yes" },
+	{ name: "Get to the end of Water Trial", jp: '水の結界の最後の部屋に到達', types: ["ganon", "fire", "lightarrow"], subtypes: ["mapcompass", "bosskey", "pg"], child: "no" }
+];
+bingoList[23] = [
+	{ name: "Both heart pieces in Lost Woods", jp: '迷いの森のハートのかけら２つ', types: ["zl"], subtypes: ["hearts", "child2", "songs"], child: "yes" },
+	{ name: "7 Maps", jp: 'マップ7つ', types: ["mapcompass", "claimcheck"], child: "yes" },
+	{ name: "Map & Compass in Spirit Temple", jp: '魂の神殿のマップとコンパス', types: ["spirit", "zl"], subtypes: ["mapcompass"], child: "yes" },
+	{ name: "Defeat Twinrova", jp: 'ツインローバ撃破', types: ["spirit"], subtypes: ["hearts"], child: "no" }
+];
+bingoList[24] = [
+	{ name: "Beat the Spirit Temple", jp: '魂の神殿クリア', types: ["spirit"], subtypes: ["hearts"], child: "no" },
+	{ name: "9 Hearts", jp: 'ハート9つ', types: ["hearts"], child: "yes" },
+	{ name: "All 5 Skulltulas in Shadow Temple", jp: '闇の神殿の黄金のスタルチュラ5匹', types: ["shadow", "zl"], subtypes: ["wallet", "bosskey"], child: "no" },
+	{ name: "Get to the end of Shadow Trial", jp: '闇の結界の最後の部屋に到達', types: ["ganon", "fire"], subtypes: ["lightarrow", "mapcompass", "bosskey", "pg"], child: "no" }
+];
+bingoList[25] = [
+	{ name: "7 Compasses", jp: 'コンパス7つ', types: ["mapcompass"], child: "no" },
+	{ name: "All 5 Skulltulas in Water Temple", jp: '水の神殿の黄金のスタルチュラ5匹', types: ["water", "zl"], child: "no" },
+	{ name: "Two Fairy Spells", jp: '魔法のアイテム２つ', types: ["zl", "spirit"], subtypes: ["child2"], child: "yes" },
+	{ name: "Green Gauntlets", jp: '緑のグローブ', types: ["strength", "bulletbag", "zl", "atrade", "saria"], subtypes: ["wallet"], child: "no" }
+];

--- a/versions/v8/v8.5/generator.js
+++ b/versions/v8/v8.5/generator.js
@@ -1,0 +1,314 @@
+//NOTICE: As of version 6, this script will only generate cards correctly for Ocarina of Time bingo
+//and as shuch should be saved alongside the regular bingo script.
+ootBingoGenerator = function(bingoList, opts) {
+	if(!opts) opts = {};
+	var LANG = opts.lang || 'name';
+	var SEED = opts.seed || Math.ceil(999999 * Math.random()).toString();
+	Math.seedrandom(SEED);
+	var MODE = opts.mode || 'normal';
+  
+	//giuocob 16-8-12: lineCheckList[] has been replaced to allow for removal of all-child rows
+	//Note: the rowElements relation is simply the inverse of the rowCheckList relation
+	var rowElements = {};
+	rowElements["row1"] = [1,2,3,4,5];
+	rowElements["row2"] = [6,7,8,9,10];
+	rowElements["row3"] = [11,12,13,14,15];
+	rowElements["row4"] = [16,17,18,19,20];
+	rowElements["row5"] = [21,22,23,24,25];
+	rowElements["col1"] = [1,6,11,16,21];
+	rowElements["col2"] = [2,7,12,17,22];
+	rowElements["col3"] = [3,8,13,18,23];
+	rowElements["col4"] = [4,9,14,19,24];
+	rowElements["col5"] = [5,10,15,20,25];
+	rowElements["tlbr"] = [1,7,13,19,25];
+	rowElements["bltr"] = [5,9,13,17,21];
+
+	//Given an object that maps keys to flat arrays, invert said object
+	function invertObject(obj) {
+		var ret = {};
+		Object.keys(obj).forEach(function(key) {
+			obj[key].forEach(function(item) {
+				if(!ret[item]) ret[item] = [];
+				ret[item].push(key);
+			});
+		});
+		return ret;
+	}
+
+	rowCheckList = invertObject(rowElements);
+
+
+
+
+	//Main entry point
+	function makeCard() {
+		var bingoBoard = []; //the board itself stored as an array first
+		for (var i=1;i<=25;i++) {
+			if(MODE == "short")
+			{
+		        bingoBoard[i] = {difficulty: difficulty(i), child: "yes"};
+		    }
+		    else
+		    {
+				bingoBoard[i] = {difficulty: difficulty(i), child: "no"};
+			}
+		}                                          // in order 1-25
+	  
+	  
+	    //giuocob 19-2-13: bingoBoard is no longer populated left to right:
+	    //It is now populated mostly randomly, with high difficult goals and
+	    //goals on the diagonals out in front
+	    var populationOrder = [];
+	    populationOrder[1] = 13;   //Populate center first
+	    var diagonals = [1,7,19,25,5,9,17,21];
+	    shuffle(diagonals);
+	    populationOrder = populationOrder.concat(diagonals);   //Next populate diagonals
+	    var nondiagonals = [2,3,4,6,8,10,11,12,14,15,16,18,20,22,23,24];
+	    shuffle(nondiagonals);
+	    populationOrder = populationOrder.concat(nondiagonals);   //Finally add the rest of the squares
+	    //Lastly, find location of difficulty 23,24,25 elements and put them out front
+	    for(var k=23;k<=25;k++)
+	    {
+			var currentSquare = getDifficultyIndex(k);
+			if(currentSquare == 0) continue;
+			for(var i=1;i<25;i++)
+			{
+				if(populationOrder[i] == currentSquare)
+				{
+					populationOrder.splice(i,1);
+					break;
+				}
+			}
+			populationOrder.splice(1,0,currentSquare);
+		}
+
+	    
+	  
+	    //Populate the bingo board in the array
+	    //giuocob 16-8-12: changed this section to:
+	    //1. Support uniform goal selection by shuffling arrays before checking goals
+	    //2. Remove all child rows by checking child tag
+	    //3. If no goal is suitable, instead of choosing goal with lowest synergy, now next difficulty up is checked
+	    for(var i=1;i<=25;i++)
+	    {
+			var sq = populationOrder[i];
+			var getDifficulty = bingoBoard[sq].difficulty;
+			var goalArray = getShuffledGoals(getDifficulty);
+			var j=0, synergy=0, spill = 0, currentObj=null, minSynObj=null;
+			do
+			{
+				currentObj = goalArray[j];
+				synergy = checkLine(sq,currentObj);
+				if(minSynObj == null || synergy < minSynObj.synergy)
+				{
+					minSynObj = {synergy: synergy, value: currentObj};
+				}
+				j++;
+				if(j >= goalArray.length)
+				{
+					getDifficulty++;
+					spill++;
+					if(getDifficulty > 25) {
+						return false;  //HIT THE PANIC BUTTON, RUN FOR THE HILLS
+					} else if(spill >=3) {
+						return false;  //THIS BINGO CARD IS IN UNACCEPTABLE CONDITION
+					} else {
+					    goalArray = getShuffledGoals(getDifficulty);
+					    j = 0;
+					}
+				}
+			} while(synergy != 0);   //Perhaps increase to 1 if difficulty increases happen too often
+			
+	    
+		    bingoBoard[sq].types = minSynObj.value.types;
+		    bingoBoard[sq].subtypes = minSynObj.value.subtypes;
+		    bingoBoard[sq].name = minSynObj.value[LANG] || minSynObj.value.name;
+		    bingoBoard[sq].child = minSynObj.value.child;
+		    bingoBoard[sq].synergy = minSynObj.synergy;
+	    }
+
+	    return bingoBoard;
+
+
+
+
+    	function mirror(i) {
+			if      (i == 0) { i = 4; }
+			else if (i == 1) { i = 3; }
+			else if (i == 3) { i = 1; }
+			else if (i == 4) { i = 0; }
+			return i;
+		}
+
+		function difficulty(i) {
+			// To create the magic square we need 2 random orderings of the numbers 0, 1, 2, 3, 4.
+			// The following creates those orderings and calls them Table5 and Table1
+			
+			var Num3 = SEED%1000;	// Table5 will use the ones, tens, and hundreds digits.
+
+			var Rem8 = Num3%8;
+			var Rem4 = Math.floor(Rem8/2);
+			var Rem2 = Rem8%2;
+			var Rem5 = Num3%5;
+			var Rem3 = Num3%3;	// Note that Rem2, Rem3, Rem4, and Rem5 are mathematically independent.
+			var RemT = Math.floor(Num3/120);	// This is between 0 and 8		
+
+			// The idea is to begin with an array containing a single number, 0.
+			// Each number 1 through 4 is added in a random spot in the array's current size.
+			// The result - the numbers 0 to 4 are in the array in a random (and uniform) order.
+			var Table5 = [0];
+			Table5.splice(Rem2, 0, 1);
+			Table5.splice(Rem3, 0, 2);
+			Table5.splice(Rem4, 0, 3);
+			Table5.splice(Rem5, 0, 4);
+
+			Num3 = Math.floor(SEED/1000);	// Table1 will use the next 3 digits.
+			Num3 = Num3%1000;
+
+			Rem8 = Num3%8;
+			Rem4 = Math.floor(Rem8/2);
+			Rem2 = Rem8%2;
+			Rem5 = Num3%5;
+			Rem3 = Num3%3;
+			RemT = RemT * 8 + Math.floor(Num3/120);	 // This is between 0 and 64.
+
+			var Table1 = [0];
+			Table1.splice(Rem2, 0, 1);
+			Table1.splice(Rem3, 0, 2);
+			Table1.splice(Rem4, 0, 3);
+			Table1.splice(Rem5, 0, 4);
+
+			i--;
+			RemT = RemT%5;		//  Between 0 and 4, fairly uniformly.
+			x = (i+RemT)%5;		//  RemT is horizontal shift to put any diagonal on the main diagonal.
+			y = Math.floor(i/5);
+
+			// The Tables are set into a single magic square template
+			// Some are the same up to some rotation, reflection, or row permutation.
+			// However, all genuinely different magic squares can arise in this fashion.
+			var e5 = Table5[(x + 3*y)%5];
+			var e1 = Table1[(3*x + y)%5];
+
+			// Table5 controls the 5* part and Table1 controls the 1* part.
+			value = 5*e5 + e1;
+
+			if (MODE == "short") { value = Math.floor(value/2); } // if short mode, limit difficulty
+		    	else if (MODE == "long") { value = Math.floor((value + 25) / 2); }
+		    	value++;
+			return value;
+		}
+
+		//Uniformly shuffles an array (note: the original array will be changed)
+		function shuffle(toShuffle)
+		{
+			for(var i=0;i<toShuffle.length;i++)
+			{
+				var randElement = Math.floor(Math.random()*(i+1));
+				var temp = toShuffle[i];
+				toShuffle[i] = toShuffle[randElement];
+				toShuffle[randElement] = temp;
+			}
+		}
+
+		//Get a uniformly shuffled array of all the goals of a given difficulty tier
+		function getShuffledGoals(difficulty)
+		{
+			var newArray = bingoList[difficulty].slice();
+			shuffle(newArray);
+			return newArray;
+		}
+
+		//Given a difficulty as an argument, find the square that contains that difficulty
+		function getDifficultyIndex(difficulty)
+		{
+			for(var i=1;i<=25;i++)
+			{
+				if(bingoBoard[i].difficulty == difficulty)
+				{
+					return i;
+				}
+			}
+			return 0;
+		}
+		  
+
+
+		function checkLine(i, testsquare)
+		{
+			var typesA = testsquare.types || [];
+			var subtypesA = testsquare.subtypes || [];
+			var synergy = 0;
+			var rows = rowCheckList[i], elements = [];
+			var childCount = 0;
+			for(var k=0;k<rows.length;k++)
+			{
+				elements = rowElements[rows[k]];
+				childCount = 0;
+				for(var m=0;m<elements.length;m++)
+				{
+					var testsquare2 = bingoBoard[elements[m]];
+					var typesB = testsquare2.types || [];
+					var subtypesB = testsquare2.subtypes || [];
+					if(typeof typesB != 'undefined')
+					{
+						function matchArrays(arr1, arr2) {
+							for(var n=0;n<arr1.length;n++) {
+								for(var p=0;p<arr2.length;p++) {
+									if(arr1[n] == arr2[p]) synergy++;
+								}
+							}
+						}
+
+						matchArrays(typesA, typesB);
+						matchArrays(typesA, subtypesB);
+						matchArrays(subtypesA, typesB);
+					}
+					if(bingoBoard[elements[m]].child == "yes")
+					{
+						childCount++;
+					}
+				}
+				//Remove child-only rows, remove adult goals from short
+				if(MODE == "short")
+				{
+					if(testsquare.child == "no")
+					{
+						childCount--;
+					}
+					if(childCount < 5)
+					{
+						synergy += 3;
+					}
+				}
+				else
+				{
+					if(testsquare.child == "yes")
+					{
+						childCount++;
+					}
+					if(childCount > 4)
+					{
+						synergy += 3;
+					}
+				}
+			}
+			return synergy;
+		}
+	}
+
+
+	//Loop over cards until one is accepted.
+	var card;
+	var iterations = 0;
+	while(true) {
+		iterations++;
+		card = makeCard();
+		if(card === false) {
+			continue;
+		} else {
+			break;
+		}
+	}
+  
+  	return card;
+}

--- a/versions/v8/v8.5/goal-list.js
+++ b/versions/v8/v8.5/goal-list.js
@@ -1,0 +1,213 @@
+var bingoList = [];
+bingoList["info"] = {
+version: "v8.5"
+};
+bingoList[1] = [
+	{ name: "Bottled Fairy", jp: 'ビン(妖精)', types: ["bottle"], child: "yes" },
+	{ name: "Bullet Bag (50)", jp: 'デクのタネ袋(50)', types: ["bulletbag"], child: "yes" },
+	{ name: "Bomb Bag (30)", jp: 'ボム袋(30)', types: ["bombbag"], child: "yes" },
+	{ name: "Lens of Truth", jp: 'まことのメガネ', types: ["botw"], child: "yes" } ,
+	{ name: "Defeat a Skull Kid", jp: 'スタルキッド撃破', types: ["skullkid"], child: "yes" },
+	{ name: "At least 30 Deku Nuts", jp: 'デクの実30個以上', types: ["nuts"], child: "yes" }
+];
+bingoList[2] = [
+	{ name: "Map & Compass in Dodongo's Cavern", jp: 'ドドンゴの洞窟のマップとコンパス', types: ["dc"], subtypes: ["mapcompass"], child: "yes" },
+	{ name: "Map & Compass in Deku Tree", jp: 'デクの樹様の中のマップとコンパス', types: ["deku"], subtypes: ["mapcompass"], child: "yes" },
+	{ name: "Map & Compass in Bottom of the Well", jp: '井戸の底のマップとコンパス', types: ["botw"], subtypes: ["mapcompass"], child: "yes" },
+	{ name: "Giant's Knife", jp: '巨人のナイフ', types: ["swords"], subtypes: ["wallet"], child: "no" },
+	{ name: "Minuet of Forest", jp: '森のメヌエット', types: ["forest"], subtypes: ["songs"], child: "no" },
+	{ name: "Goron Tunic", jp: 'ゴロンの服', types: ["tunics", "dmc", "fire"], child: "no" },
+	{ name: "Zora Tunic", jp: 'ゾーラの服', types: ["tunics", "ice"], child: "no" }
+];
+bingoList[3] = [
+	{ name: "Both heart pieces in Death Mountain Crater", jp: 'デスマウンテン火口のハートのかけら２つ', types: ["dmc", "fire"], subtypes: ["hearts"], child: "yes" },
+	{ name: "Fairy Slingshot", jp: '妖精のパチンコ', types: ["bulletbag", "deku"], child: "yes" },
+	{ name: "At least 3 songs", jp: '歌3つ以上', types: ["songs", "zl"], child: "yes" },
+	{ name: "Quiver (40)", jp: '矢立て(40)', types: ["atrade", "forest", "quiver"], child: "no" },
+	{ name: "Defeat all Lizalfos in Dodongo's Cavern", jp: 'ドドンゴの洞窟のリザルフォス全て撃破', types: ["dc"], child: "yes" },
+	{ name: "Bolero of Fire", jp: '炎のボレロ', types: ["dmc", "fire"], subtypes: ["songs"], child: "no" }
+];
+bingoList[4] = [
+	{ name: "30 Deku Sticks", jp: 'デクの棒30本', types: ["atrade"], child: "yes" },
+	{ name: "Defeat King Dodongo", jp: 'キングドドンゴ撃破', types: ["dc", "kd"], subtypes: ["hearts"], child: "yes" },
+	{ name: "Fire Temple Boss Key", jp: '炎の神殿のボス部屋のカギ', types: ["fire"], subtypes: ["bosskey"], child: "no"},
+	{ name: "Ruto's Letter", jp: 'ルトの手紙', types: ["bottle"], child: "yes" },
+	{ name: "Ice Arrows", jp: '氷の矢', types: ["fortress", "quiver"], subtypes: ["kd"], child: "yes" },
+	{ name: "Map & Compass in Shadow Temple", jp: '闇の神殿のマップとコンパス', types: ["shadow"], subtypes: ["mapcompass"], child: "yes" }
+];
+bingoList[5] = [
+	{ name: "3 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ3つ', types: ["fortress"], child: "yes" },
+	{ name: "Bullet Bag (40)", jp: 'デクのタネ袋(40)', types: ["bulletbag", "deku"], child: "yes" },
+	{ name: "Blue Fire", jp: '青い炎', types: ["ice", "bottle", "ganon"], child: "yes" },
+	{ name: "Defeat Queen Gohma", jp: 'ゴーマ撃破', types: ["deku", "ganon"], subtypes: ["hearts"], child: "yes" },
+	{ name: "All 3 Kokiri Forest area Skulltulas", jp: 'コキリの森エリアの黄金のスタルチュラ３匹', types: ["forest"], subtypes: ["wallet"], child: "no" },
+	{ name: "Ice Cavern Heart Piece", jp: '氷の洞窟のハートのかけら', types: ["ice"], subtypes: ["hearts", "mapcompass"], child: "yes" },
+	{ name: "3 Tunics", jp: '服3種類', types: ["tunics", "ice", "fire"], child: "no" },
+	{ name: "Water Temple Boss Key", jp: '水の神殿のボス部屋のカギ', types: ["water", "fortress"], subtypes: ["bosskey"], child: "no" }
+];
+bingoList[6] = [
+	{ name: "4 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ4つ', types: ["fortress"], child: "yes" },
+	{ name: "Map & Compass in Ice Cavern", jp: '氷の洞窟のマップとコンパス', types: ["ice"], subtypes: ["mapcompass"], child: "yes" },
+	{ name: "Defeat a White Wolfos", jp: 'ホワイトウルフォス撃破', types: ["ice", "fortress"], subtypes: ["mapcompass"], child: "yes" },
+	{ name: "Ganon's Castle Boss Key", jp: 'ガノン城のボス部屋のカギ', types: ["ganon", "deku"], subtypes: ["bosskey"], child: "yes" },
+	{ name: "All 3 Skulltulas in Bottom of the Well", jp: '井戸の底の黄金のスタルチュラ3匹', types: ["botw"], subtypes: ["wallet"], child: "yes" },
+	{ name: "Cow in House", jp: '牛(リンクの家)', types: ["cow"], child: "no" },
+	{ name: "Beat the Deku Tree", jp: 'デクの樹様の中クリア', types: ["deku", "ganon"], child: "yes" },
+	{ name: "All 3 Skulltulas in Ice Cavern", jp: '氷の洞窟の黄金のスタルチュラ3匹', types: ["ice"], subtypes: ["wallet", "mapcompass"], child: "yes" }
+];
+bingoList[7] = [
+	{ name: "Beat Dodongo's Cavern", jp: 'ドドンゴの洞窟クリア', types: ["dc", "fortress", "kd"], child: "yes" },
+	{ name: "Both Gerudo's Fortress area Skulltulas", jp: 'ゲルドの砦の黄金のスタルチュラ2匹', types: ["fortress"], subtypes: ["wallet"], child: "no" },
+	{ name: "Milk", jp: 'ロンロン牛乳', types: ["lonlon", "bottle"], child: "yes" },
+	{ name: "All 4 Lost Woods area Skulltulas", jp: '迷いの森エリアの黄金のスタルチュラ4匹', types: ["forest"], subtypes: ["wallet"], child: "no" },
+	{ name: "Fill all 4 Bottle Slots", jp: '4つの空きビンスロットを全て埋める', types: ["bottle"], child: "yes" },
+	{ name: "Blue Potion", jp: '青いクスリ', types: ["atrade", "zl"], child: "no" },
+	{ name: "At least 4 songs", jp: '歌4つ以上', types: ["songs", "atrade", "zl"], subtypes: ["child2"], child: "yes" }
+];
+bingoList[8] = [
+	{ name: "Giant's Wallet", jp: '巨人のサイフ', types: ["wallet"], child: "yes" },
+	{ name: "Plant bean in Death Mountain Crater", jp: 'デスマウンテン火口の土にマメを植える', types: ["dmc", "beans"], subtypes: ["child2"], child: "yes" },
+	{ name: "Epona's Song", jp: 'エポナの歌', types: ["lonlon"], subtypes: ["songs"], child: "yes" },
+	{ name: "Iron Boots", jp: 'ヘビーブーツ', types: ["ice", "boots"], subtypes: ["mapcompass"], child: "yes" },
+	{ name: "5 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ5つ', types: ["fortress"], child: "yes" },
+	{ name: "6 Hearts", jp: 'ハート6つ', types: ["hearts"], child: "yes" },
+	{ name: "Defeat Phantom Ganon", jp: 'ファントムガノン撃破', types: ["forest", "pg"], subtypes: ["hearts"], child: "yes" },
+	{ name: "Map & Compass in Water Temple", jp: '水の神殿のマップとコンパス', types: ["water"], subtypes: ["mapcompass"], child: "yes" }
+];
+bingoList[9] = [
+	{ name: "3 Swords & 3 Tunics", jp: '剣3種類と服3種類', types: ["swords", "tunics", "ice", "fire"], subtypes: ["wallet"], child: "no" },
+	{ name: "3 Boots", jp: '靴3種類', types: ["ice", "boots"], subtypes: ["mapcompass"], child: "yes" },
+	{ name: "All 5 Skulltulas in Dodongo's Cavern", jp: 'ドドンゴの洞窟の黄金のスタルチュラ5匹', types: ["dc"], subtypes: ["wallet"], child: "yes" },
+	{ name: "Defeat Morpha", jp: 'モーファ撃破', types: ["water"], subtypes: ["hearts"], child: "yes" },
+	{ name: "Beat the Forest Temple", jp: '森の神殿クリア', types: ["forest", "pg"], subtypes: ["hearts"], child: "yes" }
+];
+bingoList[10] = [
+	{ name: "500 Rupees", jp: '500ルピー', types: ["wallet"], child: "yes" },
+	{ name: "All 4 Skulltulas in Deku Tree", jp: 'デクの樹様の中の黄金のスタルチュラ4匹', types: ["deku"], subtypes: ["wallet"], child: "yes" },
+	{ name: "At least 7 Magic Beans", jp: '魔法のマメ7つ以上', types: ["beans"], subtypes: ["child2", "wallet"], child: "yes" },
+	{ name: "Defeat Big Octo", jp: '大オクタ撃破', types: ["jabu", "ice"], child: "yes" },
+	{ name: "37th heart piece (Child Fortress)", jp: '37番目のハートのかけら(子供のゲルドの砦)', types: ["fortress"], subtypes: ["hearts", "kd"], child: "yes" },
+	{ name: "Beat the Water Temple", jp: '水の神殿クリア', types: ["water"], subtypes: ["hearts"], child: "yes" },
+	{ name: "Forest Medallion", jp: '森のメダル', types: ["forest", "lightarrow", "atrade", "zl", "pg"], subtypes: ["hearts"], child: "yes" },
+	{ name: "6 unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ6つ', types: ["fortress"], child: "yes" },
+	{ name: "Requiem of Spirit", jp: '魂のレクイエム', types: ["spirit"], subtypes: ["songs"], child: "yes" },
+	{ name: "At least 6 songs", jp: '歌6つ以上', types: ["songs", "atrade", "zl"], subtypes: ["child2"], child: "no" }
+];
+bingoList[11] = [
+	{ name: "All 4 Lon-Lon Ranch area Skulltulas", jp: 'ロンロン牧場エリアの黄金のスタルチュラ4匹', types: ["jabu", "lonlon"], subtypes: ["wallet"], child: "yes" },								
+	{ name: "Defeat Bongo-Bongo", jp: 'ボンゴボンゴ撃破', types: ["shadow"], subtypes: ["hearts", "bosskey"], child: "yes" },		   
+	{ name: "At least 4 Skulltulas in Shadow Temple", jp: '闇の神殿の黄金のスタルチュラ4匹以上', types: ["shadow"], subtypes: ["wallet"], child: "no" },
+	{ name: "All 8 Kakariko area Skulltulas", jp: 'カカリコ村エリアの黄金のスタルチュラ8匹', types: ["botw"], subtypes: ["wallet"], child: "no" },
+	{ name: "Mirror Shield", jp: 'ミラーシールド', types: ["shields", "spirit"], child: "yes" },
+	{ name: "All 5 Skulltulas in Forest Temple", jp: '森の神殿の黄金のスタルチュラ5匹', types: ["forest"], subtypes: ["wallet"], child: "no" },
+	{ name: "Water Medallion", jp: '水のメダル', types: ["water", "lightarrow", "atrade", "zl"], subtypes: ["hearts"], child: "yes" },
+	{ name: "Gerudo's Card", jp: 'ゲルドの会員証', types: ["fortress"], child: "yes" },
+	{ name: "Defeat Amy (Green Poe)", jp: 'エイミー撃破(緑のポウ)ｴ', types: ["forest", "fortress", "quiver"], subtypes: ["mapcompass", "bosskey"], child: "no" }
+];
+bingoList[12] = [
+	{ name: "Beat the Shadow Temple", jp: '闇の神殿クリア', types: ["shadow"], subtypes: ["hearts", "bosskey"], child: "yes" },
+	{ name: "Get to the end of Fire Trial", jp: '炎の結界の最後の部屋に到達', types: ["ganon", "strength", "fire"], subtypes: ["bosskey"], child: "no" },
+	{ name: "Golden Gauntlets", jp: '金のグローブ', types: ["strength", "ganon", "deku"], child: "yes" },
+	{ name: "Get Bombchu chest in Spirit Temple", jp: '魂の神殿のボムチュウ取得', types: ["spirit"], child: "yes" },
+	{ name: "All 4 Skulltulas in Jabu-Jabu", jp: 'ジャブジャブ様のお腹の黄金のスタルチュラ4匹', types: ["jabu", "ice"], subtypes: ["hearts", "wallet"], child: "yes" },
+	{ name: "Fairy Bow", jp: '妖精の弓', types: ["forest", "quiver"], subtypes: ["mapcompass", "bosskey"], child: "no" },
+	{ name: "Defeat Dark Link", jp: 'ダークリンク撃破', types: ["water", "ice"], child: "no" },
+	{ name: "Fire Arrow", jp: '炎の矢', types: ["water", "fortress", "firearrow", "quiver"], child: "no" }
+];
+bingoList[13] = [
+	{ name: "Stone of Agony", jp: 'もだえ石', types: ["wallet"], child: "yes" },
+	{ name: "7 Hearts", jp: 'ハート7つ', types: ["hearts"], child: "yes" },
+	{ name: "Map & Compass in Jabu-Jabu", jp: 'ジャブジャブ様のお腹のマップとコンパス', types: ["jabu"], subtypes: ["mapcompass"], child: "yes" },
+	{ name: "Win Bombchu Bowling Prize", jp: 'ボムチュウボウリングの景品', types: ["dc", "kd"], subtypes: ["hearts", "child2"], child: "yes" },
+	{ name: "Silver Gauntlets", jp: '銀のグローブ', types: ["strength", "spirit"], child: "yes" },
+	{ name: "Longshot", jp: 'ロングフック', types: ["water", "ice"], child: "no" },
+	{ name: "3 Swords & 3 Boots", jp: '剣3種類と靴3種類', types: ["swords", "boots", "ice"], subtypes: ["wallet", "mapcompass"], child: "no" }
+];
+bingoList[14] = [
+	{ name: "Double Magic", jp: '魔力2倍', types: ["dmc", "zl"], child: "yes" },
+	{ name: "At least 8 songs", jp: '歌8つ以上', types: ["songs", "atrade", "zl"], subtypes: ["child2"], child: "no" },
+	{ name: "Bronze Gauntlets", jp: '銅のグローブ', types: ["strength", "bulletbag", "ganon", "atrade"], subtypes: ["wallet"], child: "no" },
+	{ name: "Keaton Mask", jp: 'キータンのお面', types: ["zl"], child: "yes" },
+	{ name: "3 Tunics & 3 Boots", jp: '服3種類と靴3種類', types: ["tunics", "boots", "fire", "ice"], subtypes: ["mapcompass"], child: "no" },
+	{ name: "Forest Temple Boss Key", jp: '森の神殿のボス部屋のカギ', types: ["forest", "claimcheck", "quiver"], subtypes: ["mapcompass", "bosskey"], child: "no" }
+];
+bingoList[15] = [
+	{ name: "Both Hyrule Field area Skulltulas", jp: 'ハイラル平原エリアの黄金のスタルチュラ2匹', types: ["zl", "water"], subtypes: ["wallet"], child: "yes" },
+	{ name: "Map & Compass in Forest Temple", jp: '森の神殿のマップとコンパス', types: ["forest", "quiver"], subtypes: ["mapcompass", "bosskey"], child: "no" },
+	{ name: "Map & Compass in Fire Temple", jp: '炎の神殿のマップとコンパス', types: ["fire"], subtypes: ["mapcompass", "bosskey"], child: "no" },
+	{ name: "All 4 Gerudo Valley area Skulltulas", jp: 'ゲルドの谷エリアの黄金のスタルチュラ4匹', types: ["fortress"], subtypes: ["wallet", "child2"], child: "no" },
+	{ name: "All 8 Death Mountain area Skulltulas", jp: 'デスマウンテンエリアの黄金のスタルチュラ8匹', types: ["dmc"], subtypes: ["child2", "wallet"], child: "no" },
+	{ name: "At least 9 Magic Beans", jp: '魔法のマメ9つ以上', types: ["beans"], subtypes: ["child2", "wallet"], child: "yes" },
+	{ name: "Blue Gauntlets", jp: '青のグローブ', types: ["spirit", "strength", "bulletbag", "atrade"], subtypes: ["wallet"], child: "no" }
+];
+bingoList[16] = [
+	{ name: "Megaton Hammer", jp: 'メガトンハンマー', types: ["fire"], subtypes: ["mapcompass", "bosskey"], child: "no" },
+	{ name: "6 Maps", jp: 'マップ6つ', types: ["mapcompass", "claimcheck"], child: "yes" },
+	{ name: "All 8 Zora's Domain area Skulltulas", jp: 'ゾーラの里エリアの黄金のスタルチュラ8匹', types: ["jabu", "ice"], subtypes: ["wallet"], child: "no" },
+	{ name: "Defeat Barinade", jp: 'バリネード撃破', types: ["jabu"], subtypes: ["hearts"], child: "yes" },
+	{ name: "Double Defense", jp: '防御力2倍', types: ["zl", "ganon"], child: "no" }
+];
+bingoList[17] = [
+	{ name: "At least 3 Skulltulas in Water Temple", jp: '水の神殿の黄金のスタルチュラ3匹以上', types: ["water", "ice", "zl"], subtypes: ["wallet"], child: "no"},
+	{ name: "Frog's Heart Piece", jp: 'カエルのハートのかけら(嵐の歌)', types: ["forest", "child2", "pg"], subtypes: ["hearts", "songs"], child: "no" },
+	{ name: "Shadow Temple Boss Key", jp: '闇の神殿のボス部屋のカギ', types: ["shadow", "zl"], subtypes: ["hearts", "bosskey"], child: "yes"},
+	{ name: "Defeat both Flare Dancers", jp: 'フレアダンサー2体撃破', types: ["fire"], subtypes: ["mapcompass", "bosskey"], child: "no" },
+	{ name: "Beat Jabu-Jabu's Belly", jp: 'ジャブジャブ様のお腹クリア', types: ["jabu"], subtypes: ["hearts", "child2"], child: "yes" },
+	{ name: "All 5 Skulltulas in Spirit Temple", jp: '魂の神殿の黄金のスタルチュラ5匹', types: ["spirit"], subtypes: ["wallet"], child: "yes" },
+	{ name: "3 Swords & 3 Shields", jp: '剣3種類と盾3種類', types: ["swords", "shields", "spirit"], subtypes: ["wallet"], child: "no" },
+	{ name: "Get to the end of Light Trial", jp: '光の結界の最後の部屋に到達', types: ["ganon", "zl", "strength"] , child: "no"},
+	{ name: "8 different unused keys in Gerudo Training Grounds", jp: 'ゲルドの修練場の未使用のカギ8つ', types: ["fortress", "strength", "quiver"], child: "no" }
+];
+bingoList[18] = [
+	{ name: "6 Compasses", jp: 'コンパス6つ', types: ["mapcompass"], child: "yes" },
+	{ name: "Farore's Wind", jp: 'フロルの風', types: ["zl", "ice"], child: "yes" },
+	{ name: "All 5 Skulltulas in Fire Temple", jp: '炎の神殿の黄金のスタルチュラ5匹', types: ["fire"], subtypes: ["wallet", "mapcompass", "bosskey"], child: "no" },
+	{ name: "Defeat Volvagia", jp: 'ヴァルバジア撃破', types: ["fire"], subtypes: ["hearts", "mapcompass", "bosskey", "pg"], child: "no" },
+	{ name: "At least 9 songs", jp: '歌9つ以上', types: ["songs", "atrade", "zl"], subtypes: ["child2"], child: "no" }
+];
+bingoList[19] = [
+	{ name: "Defeat Nabooru-Knuckle", jp: 'アイアンナック(ナボール)撃破', types: ["spirit"], child: "no" },
+	{ name: "Saria's Song", jp: 'サリアの歌', types: ["zl", "saria"], subtypes: ["child2", "songs"], child: "yes" },
+	{ name: "8 Hearts", jp: 'ハート8つ', types: ["hearts"], child: "yes" },
+	{ name: "3 Shields & 3 Tunics", jp: '盾3種類と服3種類', types: ["shields", "fire", "tunics", "spirit"], child: "no" },
+	{ name: "Beat the Fire Temple", jp: '炎の神殿クリア', types: ["fire", "forest"], subtypes: ["hearts", "bosskey", "mapcompass", "pg"], child: "no" }
+];
+bingoList[20] = [
+	{ name: "Light Arrows", jp: '光の矢', types: ["lightarrow", "atrade", "zl"], child: "no" },
+	{ name: "Defeat Meg (purple Poe)", jp: 'メグ撃破(紫のポウ)', types: ["forest", "quiver"], subtypes: ["mapcompass", "bosskey"], child: "no" },
+	{ name: "All 4 Wasteland/ Colossus area Skulltulas", jp: '幻影の砂漠・巨大邪神像エリアの黄金のスタルチュラ4匹', types: ["spirit"], subtypes: ["child2", "wallet", "kd"], child: "no" },
+	{ name: "Nayru's Love", jp: 'ネールの愛', types: ["spirit", "zl"], child: "yes" },
+	{ name: "Free all 9 gorons in Fire Temple", jp: '炎の神殿で９人のゴロンを全員救う', types: ["fire"], subtypes: ["mapcompass", "bosskey"], child: "no"}
+];
+bingoList[21] = [
+	{ name: "Goron Bracelet", jp: 'ゴロンの腕輪', types: ["strength", "zl", "saria"], subtypes: ["child2"], child: "yes" },
+	{ name: "All 5 Lake Hylia Skulltulas", jp: 'ハイリア湖畔エリアの黄金のスタルチュラ5匹', types: ["ice", "water"], subtypes: ["child2", "wallet", "mapcompass"], child: "no" },
+	{ name: "Din's Fire", jp: 'ディンの炎', types: ["zl"], subtypes: ["child2"], child: "yes" },
+	{ name: "Get to the end of Spirit Trial", jp: '魂の結界の最後の部屋に到達', types: ["ganon", "spirit", "quiver"], child: "no" },
+	{ name: "All 4 Market area Skulltulas", jp: '城下町エリアの黄金のスタルチュラ4匹', types: ["forest", "child2", "pg"], subtypes: ["hearts", "wallet"], child: "no" },
+	{ name: "Spooky Mask", jp: 'こわそなお面', types: ["zl", "fortress", "saria", "beans"], child: "yes" }
+];
+bingoList[22] = [
+	{ name: "7 Maps", jp: 'マップ7つ', types: ["mapcompass", "claimcheck"], child: "yes" },
+	{ name: "Spirit Temple Boss Key", jp: '魂の神殿のボス部屋のカギ', types: ["spirit", "lightarrow", "zl"], subtypes: ["bosskey"], child: "no" },
+	{ name: "Quiver (50)", jp: '矢立て(50)', types: ["quiver", "fortress", "beans"], child: "no" },
+	{ name: "3 Shields & 3 Boots", jp: '盾3種類と靴3種類', types: ["shields", "boots", "spirit", "ice"], subtypes: ["mapcompass"], child: "yes" }
+];
+bingoList[23] = [
+	{ name: "Both heart pieces in Lost Woods", jp: '迷いの森のハートのかけら２つ', types: ["zl"], subtypes: ["hearts", "child2", "songs"], child: "yes" },
+	{ name: "Map & Compass in Spirit Temple", jp: '魂の神殿のマップとコンパス', types: ["spirit", "zl"], subtypes: ["mapcompass"], child: "yes" },
+	{ name: "Defeat Twinrova", jp: 'ツインローバ撃破', types: ["spirit"], subtypes: ["hearts"], child: "no" },
+	{ name: "Get to the end of Water Trial", jp: '水の結界の最後の部屋に到達', types: ["ganon", "fire", "lightarrow"], subtypes: ["mapcompass", "bosskey", "pg"], child: "no" }
+];
+bingoList[24] = [
+	{ name: "Two Fairy Spells", jp: '魔法のアイテム２つ', types: ["zl", "spirit"], subtypes: ["child2"], child: "yes" },
+	{ name: "Beat the Spirit Temple", jp: '魂の神殿クリア', types: ["spirit"], subtypes: ["hearts"], child: "no" },
+	{ name: "All 5 Skulltulas in Shadow Temple", jp: '闇の神殿の黄金のスタルチュラ5匹', types: ["shadow", "zl"], subtypes: ["wallet", "bosskey"], child: "no" },
+	{ name: "Get to the end of Shadow Trial", jp: '闇の結界の最後の部屋に到達', types: ["ganon", "fire"], subtypes: ["lightarrow", "mapcompass", "bosskey", "pg"], child: "no" }
+];
+bingoList[25] = [
+	{ name: "9 Hearts", jp: 'ハート9つ', types: ["hearts"], child: "yes" },
+	{ name: "7 Compasses", jp: 'コンパス7つ', types: ["mapcompass"], child: "no" },
+	{ name: "All 5 Skulltulas in Water Temple", jp: '水の神殿の黄金のスタルチュラ5匹', types: ["water", "zl"], child: "no" },
+	{ name: "Green Gauntlets", jp: '緑のグローブ', types: ["strength", "bulletbag", "zl", "atrade", "saria"], subtypes: ["wallet"], child: "no" }
+];


### PR DESCRIPTION
I came across several old versions of bingo in the SRL frontend repo, and figured it would be good to centralize these versions to a more accessible location.

Minor changes were made to these versions to be able to be consumed by `bingosetup.js`.

(Note: I do not have any example boards from this time period, but the boards appeared to line up with old SRL race comments.)

Will also be looking at v1 through v5, which were also available there.