### PR TITLE
Update language for defeating boss/enemy. 

### DIFF
--- a/lib/components/info.js
+++ b/lib/components/info.js
@@ -124,7 +124,8 @@ const template = ({ newSeed, version, lang }) => `
         ${localize(
           "Beat Dungeon: When you step in the blue warp and lose control or skip the cutscene"
         )}<br />
-        ${localize("Beat a Boss/Enemy: When you strike the last blow")}<br />
+        ${localize("Defeat an Enemy: When you strike the last blow and the death animation completes. If defeating the enemy is permanent, when the associated cutscene begins")}<br />
+        ${localize("Defeat a Boss: When you strike the last blow and the death cutscene begins")}<br />
         ${localize(
           "If Wrong Warping, any items or goals associated with the wrong warp are obtained upon completion of the Wrong Warp"
         )}

--- a/localization/en.js
+++ b/localization/en.js
@@ -499,8 +499,10 @@ export default {
     "Banned Tricks": "Banned Tricks",
     "Beat Dungeon: When you step in the blue warp and lose control or skip the cutscene":
       "Beat Dungeon: When you step in the blue warp and lose control or skip the cutscene",
-    "Beat a Boss/Enemy: When you strike the last blow":
-      "Beat a Boss/Enemy: When you strike the last blow",
+    "Defeat an Enemy: When you strike the last blow and the death animation completes. If defeating the enemy is permanent, when the associated cutscene begins":
+      "Defeat an Enemy: When you strike the last blow and the death animation completes. If defeating the enemy is permanent, when the associated cutscene begins",
+    "Defeat a Boss: When you strike the last blow and the death cutscene begins":
+        "Defeat a Boss: When you strike the last blow and the death cutscene begins",
     "Bingo Popout": "Bingo Popout",
     "Blackout card": "Blackout card",
     "Border color": "Border color",

--- a/localization/ja.js
+++ b/localization/ja.js
@@ -497,7 +497,8 @@ export default {
     "Banned Tricks": null,
     "Beat Dungeon: When you step in the blue warp and lose control or skip the cutscene":
       null,
-    "Beat a Boss/Enemy: When you strike the last blow": null,
+    "Defeat an Enemy: When you strike the last blow and the death animation completes. If defeating the enemy is permanent, when the associated cutscene begins": null,
+    "Defeat a Boss: When you strike the last blow and the death cutscene begins": null,
     "Blackout card": null,
     COL1: "列１",
     COL2: "列２",


### PR DESCRIPTION
Separate "Defeat an Enemy" and "Defeat a Boss" to specify for permanent and non-permanent enemies.

This is to be consistent with the understanding that for enemies with permanent flags, the final blow must be dealt and the associated cutscene played.

For enemies without permanent flags (White Wolfos in GTG and Stalfos in Shadow/Spirit Temple), the final blow must be dealt and the death animation complete.